### PR TITLE
Fix: Docker Container Overrides throws "Do not know how to serialize a BigInt"

### DIFF
--- a/proto/discopanel/v1/common.proto
+++ b/proto/discopanel/v1/common.proto
@@ -94,7 +94,7 @@ message Server {
 
   // Additional configuration
   string additional_ports = 27; // JSON string
-  string docker_overrides = 28; // JSON string
+  DockerOverrides docker_overrides = 28;
 
   google.protobuf.Timestamp created_at = 29;
   google.protobuf.Timestamp updated_at = 30;

--- a/web/discopanel/src/lib/components/docker-overrides-editor.svelte
+++ b/web/discopanel/src/lib/components/docker-overrides-editor.svelte
@@ -95,7 +95,7 @@
 		if (overrides.capabilities) updates.capabilities = [...overrides.capabilities];
 		if (overrides.devices) updates.devices = [...overrides.devices];
 		if (overrides.networkMode) updates.networkMode = overrides.networkMode;
-		if (overrides.privileged) updates.privileged = overrides.privileged;
+		if (overrides.privileged !== undefined) updates.privileged = overrides.privileged;
 		if (overrides.user) updates.user = overrides.user;
 		if (overrides.memoryLimit) updates.memoryLimit = overrides.memoryLimit;
 		if (overrides.memoryReservation) updates.memoryReservation = overrides.memoryReservation;
@@ -440,7 +440,7 @@
 							<label class="flex items-center gap-2">
 								<Switch
 									checked={overrides?.privileged || false}
-									onCheckedChange={(checked) => updateOverride('privileged', checked || undefined)}
+									onCheckedChange={(checked) => updateOverride('privileged', checked)}
 									disabled={disabled}
 								/>
 								<span class="text-sm">Privileged Mode</span>

--- a/web/discopanel/src/lib/components/server-settings.svelte
+++ b/web/discopanel/src/lib/components/server-settings.svelte
@@ -9,7 +9,7 @@
 	import { create } from '@bufbuild/protobuf';
 	import { toast } from 'svelte-sonner';
 	import { Loader2, Save, AlertCircle } from '@lucide/svelte';
-	import type { Server, AdditionalPort, DockerOverrides } from '$lib/proto/discopanel/v1/common_pb';
+  import type { Server, AdditionalPort } from '$lib/proto/discopanel/v1/common_pb';
 	import * as _ from 'lodash-es';
 	import { ServerStatus, ModLoader } from '$lib/proto/discopanel/v1/common_pb';
 	import type { UpdateServerRequest } from '$lib/proto/discopanel/v1/server_pb';
@@ -42,15 +42,15 @@
 		}
 	}
 
-	function parseDockerOverrides(jsonStr?: string): DockerOverrides | undefined {
-		if (!jsonStr) return undefined;
-		try {
-			return JSON.parse(jsonStr);
-		} catch (e) {
-			console.error('Failed to parse dockerOverrides:', e);
-			return undefined;
-		}
-	}
+  function stringifyForBigInt(data?: any): string | undefined {
+    if (!data) return undefined;
+    try {
+      return JSON.stringify(data, (_, value) => typeof value === 'bigint' ? value.toString() : value);
+    } catch (e) {
+      console.error('Failed to parse dockerOverrides:', e);
+      return undefined;
+    }
+  }
 
 	let formData = $state<UpdateServerRequest>(
 		create(UpdateServerRequestSchema, {
@@ -69,7 +69,7 @@
 			modpackId: '', // Not used in this context
 			modpackVersionId: '', // Not used in this context
 			additionalPorts: parseAdditionalPorts(server.additionalPorts),
-			dockerOverrides: parseDockerOverrides(server.dockerOverrides)
+			dockerOverrides: server.dockerOverrides
 		})
 	);
 
@@ -104,7 +104,7 @@
 				modpackId: '', // Not used in this context
 				modpackVersionId: '', // Not used in this context
 				additionalPorts: parseAdditionalPorts(server.additionalPorts),
-				dockerOverrides: parseDockerOverrides(server.dockerOverrides)
+				dockerOverrides: server.dockerOverrides
 			});
 			saving = false;
 			isDirty = false;
@@ -133,7 +133,7 @@
 			formData.autoStart !== server.autoStart ||
 			formData.tpsCommand !== (server.tpsCommand || '') ||
 			JSON.stringify(formData.additionalPorts) !== JSON.stringify(parseAdditionalPorts(server.additionalPorts)) ||
-			JSON.stringify(formData.dockerOverrides) !== JSON.stringify(parseDockerOverrides(server.dockerOverrides));
+			stringifyForBigInt($state.snapshot(formData.dockerOverrides)) !== stringifyForBigInt(server.dockerOverrides);
 	});
 
 	async function loadOptions() {


### PR DESCRIPTION
The "Docker Container Overrides" section in the server settings throw a "Do not know how to serialize a BigInt" as soon as you changed any setting and because of this, the "Save Changes" button was always disabled. This was because the isDirty check throw the mentioned error.

I have fixed this error and also fixed some follow up errors that occurred if you did use some override settings.

During testing I also noticed that the "Memory Limit" does not work. This is not fixed with my change and should probably be addressed in the future. Right now the entered value is send to the backend but never saved or used.