### PR TITLE
[Fix] Internal Svelte Error when Removing Docker Overrides in Server Config

### DIFF
--- a/web/discopanel/src/lib/components/docker-overrides-editor.svelte
+++ b/web/discopanel/src/lib/components/docker-overrides-editor.svelte
@@ -90,6 +90,9 @@
 		// Create a new instance with updated values
 		const updates = create(DockerOverridesSchema, {});
 
+		// Create a mutable reference to updates for easier manipulation
+		const mutableUpdates = updates as Record<string, unknown>;
+
 		// Copy existing values
 		if (overrides.environment && Object.keys(overrides.environment).length > 0) updates.environment = { ...overrides.environment };
 		if (overrides.volumes && overrides.volumes.length > 0) updates.volumes = [...overrides.volumes];
@@ -112,7 +115,17 @@
 		    (typeof value === 'object' && !Array.isArray(value) && Object.keys(value).length === 0) ||
 		    (typeof value === 'number' && value === 0) ||
 		    (typeof value === 'bigint' && value === 0n)) {
-			delete updates[key];
+			
+			// Only delete field when its not an array or object, set arrays and objects to empty
+			const currentValue = updates[key];
+			if (Array.isArray(currentValue)) {
+				mutableUpdates[key as string] = [];
+			} else if (currentValue !== null && typeof currentValue === 'object') {
+				mutableUpdates[key as string] = {};
+			} else {
+				delete updates[key];
+			}
+			
 		} else {
 			updates[key] = value;
 		}

--- a/web/discopanel/src/lib/components/docker-overrides-editor.svelte
+++ b/web/discopanel/src/lib/components/docker-overrides-editor.svelte
@@ -90,9 +90,6 @@
 		// Create a new instance with updated values
 		const updates = create(DockerOverridesSchema, {});
 
-		// Create a mutable reference to updates for easier manipulation
-		const mutableUpdates = updates as Record<string, unknown>;
-
 		// Copy existing values
 		if (overrides.environment && Object.keys(overrides.environment).length > 0) updates.environment = { ...overrides.environment };
 		if (overrides.volumes && overrides.volumes.length > 0) updates.volumes = [...overrides.volumes];
@@ -117,11 +114,14 @@
 		    (typeof value === 'bigint' && value === 0n)) {
 			
 			// Only delete field when its not an array or object, set arrays and objects to empty
-			const currentValue = updates[key];
-			if (Array.isArray(currentValue)) {
-				mutableUpdates[key as string] = [];
-			} else if (currentValue !== null && typeof currentValue === 'object') {
-				mutableUpdates[key as string] = {};
+			if (key == 'environment') {
+				updates.environment = {};
+			} else if (key == 'volumes') {
+				updates.volumes = [];
+			} else if (key == 'entrypoint') {
+				updates.entrypoint = [];
+			} else if (key == 'dns') {
+				updates.dns = [];
 			} else {
 				delete updates[key];
 			}


### PR DESCRIPTION
Hey,

I fixed the internal svelte error mentioned in this [Issue](https://github.com/nickheyer/discopanel/issues/83)

I think the issue is that, when deleting the whole key and it's value the rpc-client has trouble parsing it, resulting in this convert error. 
Thats why the code now manually checks which key is beeing updated and if it is one of those being stored in an array or object it is set to an empty array or object istead of getting deleted completely.

I figured thats the best solution for now, allthough a more generic approach would be superior.