### PR TITLE
Feat custom docker labels

### DIFF
--- a/cmd/discopanel/main.go
+++ b/cmd/discopanel/main.go
@@ -72,6 +72,7 @@ func main() {
 		NetworkName: cfg.Docker.NetworkName,
 		RegistryURL: cfg.Docker.RegistryURL,
 		DNS:         cfg.Docker.DNS,
+		Labels:      cfg.Docker.Labels,
 	})
 	if err != nil {
 		log.Fatal("Failed to initialize Docker client: %v", err)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -33,7 +33,8 @@ docker:
   network_name: "discopanel-network"
   registry_url: ""
   sync_interval: 5  # Seconds between docker state sync
-
+  labels: '{ }' # confgure custom docker labels every container gets, for example: {"your.label.key": "your_label_value", "other.label.key": "other_label_value"} .
+ 
 # Storage configuration
 storage:
   data_dir: "./data"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -309,6 +309,13 @@ func validateConfig(cfg *Config) error {
 		}
 	}
 
+	// Validate custom Docker labels do not use reserved namespace 'discopanel.'
+	for k := range cfg.Docker.Labels {
+		if strings.HasPrefix(k, "discopanel.") {
+			return fmt.Errorf("custom docker labels cannot begin with 'discopanel.', namespace reserved for internal management, invalid key: %s", k)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,12 +66,13 @@ type ServerConfig struct {
 }
 
 type DockerConfig struct {
-	SyncInterval int    `mapstructure:"sync_interval" json:"sync_interval"`
-	Host         string `mapstructure:"host" json:"host"`
-	Version      string `mapstructure:"version" json:"version"`
-	NetworkName  string `mapstructure:"network_name" json:"network_name"`
-	RegistryURL  string `mapstructure:"registry_url" json:"registry_url"`
-	DNS          string `mapstructure:"dns" json:"dns"`
+	SyncInterval int               `mapstructure:"sync_interval" json:"sync_interval"`
+	Host         string            `mapstructure:"host" json:"host"`
+	Version      string            `mapstructure:"version" json:"version"`
+	NetworkName  string            `mapstructure:"network_name" json:"network_name"`
+	RegistryURL  string            `mapstructure:"registry_url" json:"registry_url"`
+	DNS          string            `mapstructure:"dns" json:"dns"`
+	Labels       map[string]string `mapstructure:"labels" json:"labels"`
 }
 
 type StorageConfig struct {
@@ -199,6 +200,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("docker.network_name", "discopanel-network")
 	v.SetDefault("docker.registry_url", "")
 	v.SetDefault("docker.dns", "")
+	v.SetDefault("docker.labels", map[string]string{})
 
 	// Storage defaults
 	dataDir, err := filepath.Abs("./data")

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -180,6 +180,7 @@ type ClientConfig struct {
 	NetworkName string
 	RegistryURL string
 	DNS         string
+	Labels      map[string]string
 }
 
 type ContainerLogStreamer interface {
@@ -472,6 +473,11 @@ func (c *Client) CreateContainer(ctx context.Context, server *models.Server, ser
 	// Apply global DNS from config
 	if c.config.DNS != "" {
 		hostConfig.DNS = []string{c.config.DNS}
+	}
+
+	// Apply global labels from config
+	if c.config.Labels != nil {
+		maps.Copy(config.Labels, c.config.Labels)
 	}
 
 	// Apply docker overrides

--- a/internal/rpc/services/server.go
+++ b/internal/rpc/services/server.go
@@ -861,6 +861,13 @@ func (s *ServerService) UpdateServer(ctx context.Context, req *connect.Request[v
 
 	// Handle docker overrides update
 	if msg.DockerOverrides != nil {
+		// Check that labels do not start with "discopanel."
+		for key := range msg.DockerOverrides.Labels {
+			if strings.HasPrefix(key, "discopanel.") {
+				return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("docker label keys cannot start with 'discopanel.', namespace reserved for internal management"))
+			}
+		}
+
 		server.DockerOverrides = msg.DockerOverrides
 		needsRecreation = true
 	}

--- a/web/discopanel/src/lib/components/docker-overrides-editor.svelte
+++ b/web/discopanel/src/lib/components/docker-overrides-editor.svelte
@@ -10,6 +10,7 @@
 	import { DockerOverridesSchema, VolumeMountSchema } from '$lib/proto/discopanel/v1/common_pb';
 	import { create } from '@bufbuild/protobuf';
 	import { Badge } from '$lib/components/ui/badge';
+	import { toast } from 'svelte-sonner';
 
 	interface Props {
 		overrides?: DockerOverrides;
@@ -24,6 +25,7 @@
 	let jsonText = $state('');
 	let jsonError = $state('');
 	let envVarCounter = $state(0); // Counter for unique env var keys
+	let labelCounter = $state(0); // Counter for unique label keys
 
 	// Count active overrides for badge
 	let activeCount = $derived(() => {
@@ -40,6 +42,7 @@
 		if (overrides.capDrop && overrides.capDrop.length > 0) count++;
 		if (overrides.devices && overrides.devices.length > 0) count++;
 		if (overrides.dns && overrides.dns.length > 0) count++;
+		if (overrides.labels && Object.keys(overrides.labels).length > 0) count++;
 		return count;
 	});
 
@@ -104,6 +107,7 @@
 		if (overrides.restartPolicy) updates.restartPolicy = overrides.restartPolicy;
 		if (overrides.entrypoint && overrides.entrypoint.length > 0) updates.entrypoint = [...overrides.entrypoint];
 		if (overrides.dns && overrides.dns.length > 0) updates.dns = [...overrides.dns];
+		if (overrides.labels && Object.keys(overrides.labels).length > 0) updates.labels = { ...overrides.labels };
 
 		// Update the specific field
 		if (value === undefined || value === null ||
@@ -203,6 +207,49 @@
 			});
 			updateOverride('volumes', volumes);
 		}
+	}
+
+	// Labels (stored as map object)
+	function addLabel() {
+		const labelMap = { ...(overrides?.labels || {}) };
+		// Generate unique key name
+		let newKey = `LABEL_${labelCounter}`;
+		while (newKey in labelMap) {
+			labelCounter++;
+			newKey = `LABEL_${labelCounter}`;
+		}
+		labelCounter++;
+		labelMap[newKey] = '';
+		updateOverride('labels', labelMap);
+	}
+
+	function updateLabel(oldKey: string, newKey: string, value: string) {
+		const labelMap = { ...(overrides?.labels || {}) };
+
+		// If label key is DiscoKey show warning
+		if(newKey.startsWith('discopanel.') && oldKey !== newKey) {
+			toast.error('This namespace is reserved for system use.');
+		}
+
+		// If key changed, remove old key
+		if (oldKey !== newKey) {
+			delete labelMap[oldKey];
+		}
+
+		// Add new key/value if key is present
+		if (newKey) {
+			labelMap[newKey] = value;
+		}
+
+		const hasKeys = Object.keys(labelMap).length > 0;
+		updateOverride('labels', hasKeys ? labelMap : undefined);
+	}
+
+	function removeLabel(key: string) {
+		const labelMap = { ...(overrides?.labels || {}) };
+		delete labelMap[key];
+		const hasKeys = Object.keys(labelMap).length > 0;
+		updateOverride('labels', hasKeys ? labelMap : undefined);
 	}
 </script>
 
@@ -532,6 +579,7 @@
 							class="h-8 text-xs"
 						/>
 					</div>
+
 					<!-- Entrypoint -->
 					<div class="space-y-2">
 						<Label for="entrypoint" class="text-sm">Entrypoint</Label>
@@ -553,6 +601,61 @@
 							class="h-8 text-xs"
 						/>
 						<p class="text-xs text-muted-foreground">Comma-separated arguments</p>
+					</div>
+					
+					<!-- Labels -->
+					<div class="space-y-3">
+						<div class="flex items-center justify-between">
+							<Label class="text-sm font-medium">Labels</Label>
+							<Button
+								type="button"
+								variant="ghost"
+								size="sm"
+								onclick={addLabel}
+								disabled={disabled}
+								class="h-7 text-xs gap-1"
+							>
+								<Plus class="h-3 w-3" />
+								Add Label
+							</Button>
+						</div>
+						{#if overrides?.labels && Object.keys(overrides.labels).length > 0}
+							<div class="rounded-lg border bg-muted/20 p-3">
+								<div class="space-y-2">
+									{#each Object.entries(overrides.labels) as [key, value] (key)}
+										<div class="flex items-center gap-2">
+											<Input
+												value={key}
+												onchange={(e) => updateLabel(key, e.currentTarget.value, value)}
+												placeholder="LABEL_NAME"
+												disabled={disabled}
+												class="h-8 font-mono text-xs flex-1"
+											/>
+											<span class="text-muted-foreground text-xs">=</span>
+											<Input
+												value={value}
+												oninput={(e) => updateLabel(key, key, e.currentTarget.value)}
+												placeholder="value"
+												disabled={disabled}
+												class="h-8 font-mono text-xs flex-1"
+											/>
+											<Button
+												type="button"
+												variant="ghost"
+												size="icon"
+												onclick={() => removeLabel(key)}
+												disabled={disabled}
+												class="h-8 w-8 hover:bg-destructive/10 hover:text-destructive"
+											>
+												<X class="h-3 w-3" />
+											</Button>
+										</div>
+									{/each}
+								</div>
+							</div>
+						{:else}
+							<div class="text-xs text-muted-foreground italic">No labels configured</div>
+						{/if}
 					</div>
 				</CardContent>
 			{/if}


### PR DESCRIPTION
Hey I implemented the requested Docker Label Support in this [Issue](https://github.com/nickheyer/discopanel/issues/77).

Docker Labels are configurable as JSON Object for example:

`
 {"your.label.key": "your_label_value", "other.label.key": "other_label_value"} 
`

via env Variable _DISCOPANEL_DOCKER_LABELS_ or in the docker section in the _config.yml_ file as shown in _config.example.yml_.

Custom Docker Labels can also be individually assigend to Minecraft Servers via Docker Overrides Section in the Server Configuration Tab.

Creating Docker Labels with namespace `discopanel.` is not allowed. 

When trying to use such Labels in yml or env, it throws an error on system startup.
When assigning via Docker Overrides it also throws an error when trying to save the config.

