### PR TITLE
feat: support nested YAML map syntax for docker labels

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -33,8 +33,13 @@ docker:
   network_name: "discopanel-network"
   registry_url: ""
   sync_interval: 5  # Seconds between docker state sync
-  labels: '{ }' # confgure custom docker labels every container gets, for example: {"your.label.key": "your_label_value", "other.label.key": "other_label_value"} .
- 
+  # Can be configure like labels: {"your.label.key": "your_label_value", "other.label.key": "other_label_value"}
+  # or
+  # labels:
+  #   your.label.key: "your_label_value"
+  #   other.label.key: "other_label_value"
+  labels: '{ }'
+
 # Storage configuration
 storage:
   data_dir: "./data"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,8 +1,8 @@
 # DiscoPanel Configuration File
 # This file contains all configuration options for DiscoPanel
-# 
+#
 # These can all be set via env, like we do in our docker compose example(s). For example:
-# 
+#
 # server:
 #   port: "8080"
 #
@@ -32,50 +32,50 @@ docker:
   version: ""
   network_name: "discopanel-network"
   registry_url: ""
-  sync_interval: 5  # Seconds between docker state sync
+  sync_interval: 5 # Seconds between docker state sync
   # Can be configure like labels: {"your.label.key": "your_label_value", "other.label.key": "other_label_value"}
   # or
   # labels:
   #   your.label.key: "your_label_value"
   #   other.label.key: "other_label_value"
-  labels: '{ }'
+  labels: "{ }"
 
 # Storage configuration
 storage:
   data_dir: "./data"
   backup_dir: "./backups"
   temp_dir: "./tmp"
-  max_upload_size: 524288000  # 500MB in bytes
+  max_upload_size: 524288000 # 500MB in bytes
 
 # Authentication configuration
 auth:
-  session_timeout: 86400  # default: 24 hours
-  anonymous_access: false  # Allow unauthenticated access
-  jwt_secret: ""  # Leave empty to auto-generate
+  session_timeout: 86400 # default: 24 hours
+  anonymous_access: false # Allow unauthenticated access
+  jwt_secret: "" # Leave empty to auto-generate
 
   # Local authentication (login via discopanel web ui)
   local:
-    enabled: true  # Enable local
-    allow_registration: false  # Allow new users to register themselves via login
+    enabled: true # Enable local
+    allow_registration: false # Allow new users to register themselves via login
 
   # OIDC authentication (login via OIDC-compliant provider, ie: keycloak, authelia, authentik, etc.)
   oidc:
     enabled: false
-    issuer_uri: ""  # OIDC Provider url (ie: http://authelia.local:9091, http://localhost:8180/realms/discopanel, etc.)
-    client_id: ""  # Client ID registered with your OIDC (like "discopanel")
-    client_secret: ""  # Client secret registered with your OIDC
-    redirect_url: ""  # Where OIDC sends users after login (ie: "http://localhost:8080/api/v1/auth/oidc/callback")
+    issuer_uri: "" # OIDC Provider url (ie: http://authelia.local:9091, http://localhost:8180/realms/discopanel, etc.)
+    client_id: "" # Client ID registered with your OIDC (like "discopanel")
+    client_secret: "" # Client secret registered with your OIDC
+    redirect_url: "" # Where OIDC sends users after login (ie: "http://localhost:8080/api/v1/auth/oidc/callback")
     scopes: ["openid", "profile", "email"]
-    role_claim: "groups"  # The token claim that contains the user's groups (usually "groups")
-    role_mapping: {}  # Mapping to groups if they arent the same name as discopanels (ie: {"my-admins": "admin", "my-users": "user"})
-    skip_tls_verify: false  # Skip TLS certificate verification (for self-signed certs)
+    role_claim: "groups" # The token claim that contains the user's groups (usually "groups")
+    role_mapping: {} # Mapping to groups if they arent the same name as discopanels (ie: {"my-admins": "admin", "my-users": "user"})
+    skip_tls_verify: false # Skip TLS certificate verification (for self-signed certs)
 
 # Upload configuration
 upload:
-  session_ttl: 240  # Upload session time-to-live in minutes (default: 4 hours)
-  default_chunk_size: 5242880  # 5MB default chunk size (client can override)
-  max_chunk_size: 10485760  # 10MB max chunk size (server enforced)
-  max_upload_size: 0  # Max total upload size in bytes (0 = unlimited)
+  session_ttl: 240 # Upload session time-to-live in minutes (default: 4 hours)
+  default_chunk_size: 5242880 # 5MB default chunk size (client can override)
+  max_chunk_size: 10485760 # 10MB max chunk size (server enforced)
+  max_upload_size: 0 # Max total upload size in bytes (0 = unlimited)
 
 # Module configuration
 module:
@@ -99,11 +99,10 @@ proxy:
 # - Server named "modded" → Connect via: modded.mc.example.com:25565
 #
 # All servers use the same port (25565) and are routed based on hostname!
-# 
+#
 # DNS Setup Required:
 # Add a wildcard DNS record: *.mc.example.com → Your server's IP
 # Or add individual A records for each server subdomain
-
 
 # Minecraft server global configuration defaults
 minecraft:
@@ -137,7 +136,7 @@ minecraft:
     icon: ""
     overrideIcon: false
     maxPlayers: 20
-    maxWorldSize: 0
+    maxWorldSize: 29999984
     allowNether: true
     announcePlayerAchievements: true
     enableCommandBlock: false
@@ -167,7 +166,7 @@ minecraft:
     entityBroadcastRangePercentage: 0
     functionPermissionLevel: 0
     networkCompressionThreshold: 0
-    opPermissionLevel: 0
+    opPermissionLevel: 4
     preventProxyConnections: false
     useNativeTransport: false
     simulationDistance: 0
@@ -194,7 +193,7 @@ minecraft:
 
     # RCON
     enableRcon: true
-    rconPassword: ""  # MUST be changed for security
+    rconPassword: "" # MUST be changed for security
     rconPort: 25575
     broadcastRconToOps: false
     rconCmdsStartup: ""

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -157,6 +157,9 @@ func Load(configPath string) (*Config, error) {
 		// Config file not found; use defaults and environment
 	}
 
+	// Flatten nested maps like docker.labels into map[string]string
+	flattenMapSetting(v, "docker.labels")
+
 	// Unmarshal config with a decode hook that handles JSON strings from env
 	var cfg Config
 	if err := v.Unmarshal(&cfg, func(dc *mapstructure.DecoderConfig) {
@@ -330,5 +333,38 @@ func jsonStringToMapHook() mapstructure.DecodeHookFuncType {
 			return data, nil
 		}
 		return m, nil
+	}
+}
+
+// flattenMapSetting flattens a nested viper setting into a flat map[string]string.
+// For example, docker.labels.com.example.enable: true becomes {"com.example.enable": "true"}.
+func flattenMapSetting(v *viper.Viper, key string) {
+	val := v.Get(key)
+	if val == nil {
+		return
+	}
+
+	m, ok := val.(map[string]any)
+	if !ok {
+		return
+	}
+
+	flat := make(map[string]string)
+	flattenMap(m, "", flat)
+	v.Set(key, flat)
+}
+
+func flattenMap(src map[string]any, prefix string, dst map[string]string) {
+	for k, v := range src {
+		key := k
+		if prefix != "" {
+			key = prefix + "." + k
+		}
+		switch val := v.(type) {
+		case map[string]any:
+			flattenMap(val, key, dst)
+		default:
+			dst[key] = fmt.Sprintf("%v", val)
+		}
 	}
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -148,7 +148,7 @@ type ServerConfig struct {
 	Icon                           *string `json:"icon" env:"ICON" default:"" desc:"URL or file path for server icon" input:"text" label:"Server Icon"`
 	OverrideIcon                   *bool   `json:"overrideIcon" env:"OVERRIDE_ICON" default:"false" desc:"Override existing server icon" input:"checkbox" label:"Override Icon"`
 	MaxPlayers                     *int    `json:"maxPlayers" env:"MAX_PLAYERS" default:"20" desc:"Maximum number of players" input:"number" label:"Max Players" system:"true"`
-	MaxWorldSize                   *int    `json:"maxWorldSize" env:"MAX_WORLD_SIZE" default:"0" desc:"Maximum world size in blocks (radius)" input:"number" label:"Max World Size"`
+	MaxWorldSize                   *int    `json:"maxWorldSize" env:"MAX_WORLD_SIZE" default:"29999984" desc:"Maximum world size in blocks (radius)" input:"number" label:"Max World Size"`
 	AllowNether                    *bool   `json:"allowNether" env:"ALLOW_NETHER" default:"true" desc:"Allow players to travel to the Nether" input:"checkbox" label:"Allow Nether"`
 	AnnouncePlayerAchievements     *bool   `json:"announcePlayerAchievements" env:"ANNOUNCE_PLAYER_ACHIEVEMENTS" default:"true" desc:"Announce player achievements" input:"checkbox" label:"Announce Player Achievements"`
 	EnableCommandBlock             *bool   `json:"enableCommandBlock" env:"ENABLE_COMMAND_BLOCK" default:"false" desc:"Enable command blocks" input:"checkbox" label:"Enable Command Blocks"`
@@ -178,7 +178,7 @@ type ServerConfig struct {
 	EntityBroadcastRangePercentage *int    `json:"entityBroadcastRangePercentage" env:"ENTITY_BROADCAST_RANGE_PERCENTAGE" default:"0" desc:"Entity broadcast range percentage" input:"number" label:"Entity Broadcast Range Percentage"`
 	FunctionPermissionLevel        *int    `json:"functionPermissionLevel" env:"FUNCTION_PERMISSION_LEVEL" default:"0" desc:"Function permission level" input:"number" label:"Function Permission Level"`
 	NetworkCompressionThreshold    *int    `json:"networkCompressionThreshold" env:"NETWORK_COMPRESSION_THRESHOLD" default:"0" desc:"Network compression threshold" input:"number" label:"Network Compression Threshold"`
-	OpPermissionLevel              *int    `json:"opPermissionLevel" env:"OP_PERMISSION_LEVEL" default:"0" desc:"OP permission level" input:"number" label:"OP Permission Level"`
+	OpPermissionLevel              *int    `json:"opPermissionLevel" env:"OP_PERMISSION_LEVEL" default:"4" desc:"OP permission level" input:"number" label:"OP Permission Level"`
 	PreventProxyConnections        *bool   `json:"preventProxyConnections" env:"PREVENT_PROXY_CONNECTIONS" default:"false" desc:"Prevent proxy connections" input:"checkbox" label:"Prevent Proxy Connections"`
 	UseNativeTransport             *bool   `json:"useNativeTransport" env:"USE_NATIVE_TRANSPORT" default:"true" desc:"Use native transport" input:"checkbox" label:"Use Native Transport"`
 	SimulationDistance             *int    `json:"simulationDistance" env:"SIMULATION_DISTANCE" default:"0" desc:"Simulation distance" input:"number" label:"Simulation Distance"`

--- a/web/discopanel/src/lib/components/server/ModuleDialog.svelte
+++ b/web/discopanel/src/lib/components/server/ModuleDialog.svelte
@@ -28,6 +28,7 @@
 		templates?: ModuleTemplate[];
 		module?: Module;
 		onSuccess: () => void;
+		onTemplateDeleted?: () => void;
 	}
 
 	interface EnvVar { key: string; value: string; }
@@ -36,7 +37,7 @@
 
 	type ConfigSection = 'general' | 'ports' | 'environment' | 'volumes' | 'advanced';
 
-	let { open = $bindable(), mode, server, templates, module, onSuccess }: Props = $props();
+	let { open = $bindable(), mode, server, templates, module, onSuccess, onTemplateDeleted }: Props = $props();
 
 	let step = $state<'select' | 'configure'>('select');
 	let selectedTemplate = $state<ModuleTemplate | null>(null);
@@ -350,6 +351,21 @@
 		step = 'configure';
 	}
 
+	async function handleDeleteTemplate(template: ModuleTemplate) {
+		const confirmed = confirm(`Are you sure you want to delete template "${template.name}"?\n\nThis cannot be undone.`);
+		if (!confirmed) return;
+
+		try {
+			await rpcClient.module.deleteModuleTemplate({ id: template.id });
+			toast.success(`Template "${template.name}" deleted`);
+			if (onTemplateDeleted) {
+				onTemplateDeleted();
+			}
+		} catch (error) {
+			toast.error(`Failed to delete template: ${error instanceof Error ? error.message : 'Unknown error'}`);
+		}
+	}
+
 	let warnings = $state<string[]>([]);
 	let warningResolve: ((proceed: boolean) => void) | null = null;
 
@@ -543,7 +559,7 @@
 
 				<!-- Content -->
 				<div class="flex-1 overflow-y-auto p-8">
-					<ModuleTemplateMenu {templates} onSelect={selectTemplate} />
+					<ModuleTemplateMenu {templates} onSelect={selectTemplate} onDelete={handleDeleteTemplate} />
 				</div>
 			</div>
 		{:else}

--- a/web/discopanel/src/lib/components/server/ModuleTemplateCreateDialog.svelte
+++ b/web/discopanel/src/lib/components/server/ModuleTemplateCreateDialog.svelte
@@ -10,7 +10,7 @@
 	import AliasHelper from '$lib/components/ui/AliasHelper.svelte';
 	import { rpcClient } from '$lib/api/rpc-client';
 	import { toast } from 'svelte-sonner';
-	import { ModuleEventType, ModuleEventAction } from '$lib/proto/discopanel/v1/module_pb';
+	import { ModuleEventType, ModuleEventAction, type ModuleTemplate } from '$lib/proto/discopanel/v1/module_pb';
 	import {
 		Loader2, Plus, Trash2, Package, X,
 		FileText, Container, Network, Variable, HardDrive, Wrench, Heart, Info
@@ -18,7 +18,9 @@
 
 	interface Props {
 		open: boolean;
-		onCreated: () => void;
+		mode?: 'create' | 'edit';
+		template?: ModuleTemplate;
+		onSuccess: () => void;
 	}
 
 	interface EnvVar {
@@ -56,9 +58,9 @@
 
 	type ConfigSection = 'basic' | 'docker' | 'ports' | 'environment' | 'volumes' | 'advanced';
 
-	let { open = $bindable(), onCreated }: Props = $props();
+	let { open = $bindable(), mode = 'create', template, onSuccess }: Props = $props();
 
-	let creating = $state(false);
+	let submitting = $state(false);
 	let activeSection = $state<ConfigSection>('basic');
 
 	// Form state
@@ -219,10 +221,63 @@
 	}
 
 	$effect(() => {
-		if (!open) {
+		if (open) {
+			if (mode === 'edit' && template) {
+				loadTemplateData(template);
+			} else if (mode === 'create') {
+				resetForm();
+			}
+		} else {
 			resetForm();
 		}
 	});
+
+	function loadTemplateData(t: ModuleTemplate) {
+		name = t.name;
+		description = t.description;
+		dockerImage = t.dockerImage;
+		healthCheckPath = t.healthCheckPath;
+		healthCheckPort = t.healthCheckPort;
+		requiresServer = t.requiresServer;
+		supportsProxy = t.supportsProxy;
+		icon = t.icon;
+		category = t.category;
+		documentation = t.documentation;
+		defaultUid = t.defaultUid;
+		defaultGid = t.defaultGid;
+		defaultInitCommand = t.defaultInitCommand;
+		defaultInitCommandDelay = t.defaultInitCommandDelay;
+		defaultRestartAfterInit = t.defaultRestartAfterInit;
+
+		try {
+			const envObj = JSON.parse(t.defaultEnv || '{}');
+			envVars = Object.entries(envObj).map(([key, value]) => ({ key, value: String(value) }));
+		} catch { envVars = []; }
+
+		try {
+			volumes = JSON.parse(t.defaultVolumes || '[]');
+		} catch { volumes = []; }
+
+		ports = t.ports.map(p => ({
+			name: p.name,
+			containerPort: p.containerPort,
+			hostPort: p.hostPort,
+			protocol: p.protocol,
+			proxyEnabled: p.proxyEnabled
+		}));
+
+		suggestedDependencies = t.suggestedDependencies.join(', ');
+		defaultHooks = t.defaultHooks.map(h => ({
+			event: h.event,
+			action: h.action,
+			command: h.command,
+			delaySeconds: h.delaySeconds,
+			condition: h.condition
+		}));
+
+		metadata = Object.entries(t.metadata || {}).map(([key, value]) => ({ key, value }));
+		activeSection = 'basic';
+	}
 
 	function resetForm() {
 		name = '';
@@ -249,12 +304,12 @@
 		activeSection = 'basic';
 	}
 
-	async function handleCreate() {
+	async function handleSubmit() {
 		if (!name.trim() || !dockerImage.trim()) return;
 
-		creating = true;
+		submitting = true;
 		try {
-			await rpcClient.module.createModuleTemplate({
+			const payload = {
 				name: name.trim(),
 				description: description.trim(),
 				dockerImage: dockerImage.trim(),
@@ -295,14 +350,22 @@
 				defaultInitCommand,
 				defaultInitCommandDelay,
 				defaultRestartAfterInit
-			});
-			toast.success(`Template "${name}" created`);
+			};
+
+			if (mode === 'edit' && template) {
+				await rpcClient.module.updateModuleTemplate({ id: template.id, ...payload });
+				toast.success(`Template "${name}" updated`);
+			} else {
+				await rpcClient.module.createModuleTemplate(payload);
+				toast.success(`Template "${name}" created`);
+			}
+			
 			open = false;
-			onCreated();
+			onSuccess();
 		} catch (error) {
-			toast.error(`Failed to create template: ${error instanceof Error ? error.message : 'Unknown error'}`);
+			toast.error(`Failed to ${mode} template: ${error instanceof Error ? error.message : 'Unknown error'}`);
 		} finally {
-			creating = false;
+			submitting = false;
 		}
 	}
 </script>
@@ -320,7 +383,7 @@
 						</div>
 						<div class="flex-1 min-w-0">
 							<h3 class="font-semibold truncate">
-								{name || 'New Template'}
+								{name || (mode === 'create' ? 'New Template' : 'Edit Template')}
 							</h3>
 							<p class="text-sm text-muted-foreground">Custom template</p>
 						</div>
@@ -1060,24 +1123,21 @@
 				</div>
 
 				<!-- Footer -->
-				<div class="flex items-center justify-end gap-3 px-8 py-5 border-t bg-muted/30">
-					<Button variant="outline" onclick={() => (open = false)} class="h-11 px-6">
-						Cancel
-					</Button>
-					<Button
-						onclick={handleCreate}
-						disabled={creating || !name.trim() || !dockerImage.trim()}
-						class="h-11 px-8 gap-2"
-					>
-						{#if creating}
-							<Loader2 class="h-4 w-4 animate-spin" />
-							Creating...
-						{:else}
-							<Package class="h-4 w-4" />
-							Create Template
-						{/if}
-					</Button>
-				</div>
+				<div class="p-4 border-t bg-muted/20 flex justify-between items-center">
+				<Button variant="ghost" onclick={() => (open = false)}>Cancel</Button>
+				<Button
+					onclick={handleSubmit}
+					disabled={!name.trim() || !dockerImage.trim() || submitting}
+					class="min-w-[120px]"
+				>
+					{#if submitting}
+						<Loader2 class="h-4 w-4 animate-spin mr-2" />
+						{mode === 'create' ? 'Creating...' : 'Saving...'}
+					{:else}
+						{mode === 'create' ? 'Create Template' : 'Save Changes'}
+					{/if}
+				</Button>
+			</div>
 			</div>
 		</div>
 	</DialogContent>

--- a/web/discopanel/src/lib/components/server/ModuleTemplateMenu.svelte
+++ b/web/discopanel/src/lib/components/server/ModuleTemplateMenu.svelte
@@ -2,15 +2,16 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
 	import DynamicIcon from '$lib/components/ui/DynamicIcon.svelte';
-	import { Package, ChevronRight } from '@lucide/svelte';
-	import type { ModuleTemplate } from '$lib/proto/discopanel/v1/module_pb';
+	import { Package, ChevronRight, Trash2 } from '@lucide/svelte';
+	import { ModuleTemplateType, type ModuleTemplate } from '$lib/proto/discopanel/v1/module_pb';
 
 	interface Props {
 		templates?: ModuleTemplate[];
 		onSelect: (template: ModuleTemplate) => void;
+		onDelete?: (template: ModuleTemplate) => void;
 	}
 
-	let { templates, onSelect }: Props = $props();
+	let { templates, onSelect, onDelete }: Props = $props();
 
 	let selectedCategory = $state<string | null>(null);
 
@@ -55,8 +56,11 @@
 
 <div class="space-y-3">
 	{#each filteredTemplates as template (template.name)}
-		<button
-			class="w-full flex items-center gap-5 p-5 rounded-xl border bg-card text-left hover:bg-muted/50 hover:border-primary/50 transition-all group"
+		<!-- svelte-ignore a11y_click_events_have_key_events -->
+		<!-- svelte-ignore a11y_interactive_supports_focus -->
+		<div
+			class="w-full flex items-center gap-5 p-5 rounded-xl border bg-card text-left hover:bg-muted/50 hover:border-primary/50 transition-all group cursor-pointer"
+			role="button"
 			onclick={() => onSelect(template)}
 		>
 			<div class="h-14 w-14 rounded-xl bg-primary/10 flex items-center justify-center shrink-0">
@@ -73,8 +77,24 @@
 					{template.description || 'No description provided'}
 				</p>
 			</div>
-			<ChevronRight class="h-5 w-5 text-muted-foreground group-hover:text-primary transition-colors shrink-0" />
-		</button>
+			
+			<div class="flex items-center gap-2 shrink-0">
+				{#if template.type === ModuleTemplateType.CUSTOM && onDelete}
+					<Button
+						variant="ghost"
+						size="icon"
+						class="opacity-0 group-hover:opacity-100 transition-opacity text-destructive hover:text-destructive hover:bg-destructive/10"
+						onclick={(e) => {
+							e.stopPropagation();
+							onDelete?.(template);
+						}}
+					>
+						<Trash2 class="h-5 w-5" />
+					</Button>
+				{/if}
+				<ChevronRight class="h-5 w-5 text-muted-foreground group-hover:text-primary transition-colors" />
+			</div>
+		</div>
 	{/each}
 </div>
 

--- a/web/discopanel/src/lib/components/server/ServerModules.svelte
+++ b/web/discopanel/src/lib/components/server/ServerModules.svelte
@@ -513,6 +513,7 @@
 	{server}
 	{templates}
 	onSuccess={handleModuleCreated}
+	onTemplateDeleted={loadTemplates}
 />
 
 {#if selectedModule}

--- a/web/discopanel/src/routes/+layout.svelte
+++ b/web/discopanel/src/routes/+layout.svelte
@@ -38,7 +38,7 @@
 	import { Toaster } from '$lib/components/ui/sonner';
 	import GlobalLoading from '$lib/components/global-loading.svelte';
 
-	import { Server, Home, Settings, Package, User as UserIcon, LogOut, LogIn, FileText, Sun, Moon } from '@lucide/svelte';
+	import { Server, Home, Settings, Package, User as UserIcon, LogOut, LogIn, FileText, Sun, Moon, Puzzle } from '@lucide/svelte';
 	import { toggleMode, mode } from 'mode-watcher';
 	import { ServerStatus, type User } from '$lib/proto/discopanel/v1/common_pb';
 
@@ -182,6 +182,18 @@
 										{/snippet}
 									</SidebarMenuButton>
 								</SidebarMenuItem>
+								{#if showSettingsNav}
+									<SidebarMenuItem>
+										<SidebarMenuButton isActive={page.url.pathname.startsWith('/modules')}>
+											{#snippet child({ props })}
+												<a href={resolvePath('/modules')} {...props}>
+													<Puzzle class="h-4 w-4" />
+													<span class="group-data-[collapsible=icon]:hidden">Modules</span>
+												</a>
+											{/snippet}
+										</SidebarMenuButton>
+									</SidebarMenuItem>
+								{/if}
 								{#if showSettingsNav}
 									<SidebarMenuItem>
 										<SidebarMenuButton isActive={page.url.pathname === '/settings'}>

--- a/web/discopanel/src/routes/modules/+page.svelte
+++ b/web/discopanel/src/routes/modules/+page.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import { Tabs, TabsContent, TabsList, TabsTrigger } from '$lib/components/ui/tabs';
+	import { Puzzle, Server, Layers } from '@lucide/svelte';
+	import TemplateManagement from './TemplateManagement.svelte';
+	import ActiveModules from './ActiveModules.svelte';
+
+	let activeTab = $state('templates');
+</script>
+
+<svelte:head>
+	<title>Modules - DiscoPanel</title>
+</svelte:head>
+
+<div class="flex-1 space-y-8 h-full p-8 pt-6 bg-linear-to-br from-background to-muted/10">
+	<div class="flex items-center justify-between pb-6 border-b-2 border-border/50">
+		<div class="flex items-center gap-4">
+			<div class="h-16 w-16 rounded-2xl bg-linear-to-br from-primary/20 to-primary/10 flex items-center justify-center shadow-lg">
+				<Puzzle class="h-8 w-8 text-primary" />
+			</div>
+			<div class="space-y-1">
+				<h2 class="text-4xl font-bold tracking-tight bg-linear-to-r from-foreground to-foreground/70 bg-clip-text text-transparent">Modules</h2>
+				<p class="text-base text-muted-foreground">Manage global templates and view active instances</p>
+			</div>
+		</div>
+	</div>
+
+	<Tabs value={activeTab} onValueChange={(v) => activeTab = v || activeTab} class="space-y-6">
+		<TabsList class="flex w-fit gap-1">
+			<TabsTrigger value="templates" class="flex items-center gap-2 px-4">
+				<Layers class="h-4 w-4" />
+				Templates
+			</TabsTrigger>
+			<TabsTrigger value="active" class="flex items-center gap-2 px-4">
+				<Server class="h-4 w-4" />
+				Active Instances
+			</TabsTrigger>
+		</TabsList>
+
+		<TabsContent value="templates" class="space-y-4">
+			<TemplateManagement />
+		</TabsContent>
+
+		<TabsContent value="active" class="space-y-4">
+			<ActiveModules />
+		</TabsContent>
+	</Tabs>
+</div>

--- a/web/discopanel/src/routes/modules/ActiveModules.svelte
+++ b/web/discopanel/src/routes/modules/ActiveModules.svelte
@@ -1,0 +1,319 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button';
+	import { Card, CardContent } from '$lib/components/ui/card';
+	import { Badge } from '$lib/components/ui/badge';
+	import { rpcClient, silentCallOptions } from '$lib/api/rpc-client';
+	import { toast } from 'svelte-sonner';
+	import type { Module } from '$lib/proto/discopanel/v1/module_pb';
+	import { ModuleStatus } from '$lib/proto/discopanel/v1/module_pb';
+	import { Loader2, Play, Square, RotateCw, Settings, Trash2, Terminal, Cpu, Server, ExternalLink, Package, RefreshCw } from '@lucide/svelte';
+	import ModuleDialog from '$lib/components/server/ModuleDialog.svelte';
+	import ModuleLogsDialog from '$lib/components/server/ModuleLogsDialog.svelte';
+	import { onMount, onDestroy } from 'svelte';
+
+	let modules = $state<Module[]>([]);
+	let loading = $state(true);
+	let actionLoading = $state<string | null>(null);
+
+	// Dialog state
+	let editDialogOpen = $state(false);
+	let logsDialogOpen = $state(false);
+	let selectedModule = $state<Module | null>(null);
+
+	let pollingInterval: ReturnType<typeof setInterval> | null = null;
+
+	onMount(() => {
+		loadModules();
+		pollingInterval = setInterval(() => loadModules(true), 5000);
+	});
+
+	onDestroy(() => {
+		if (pollingInterval) {
+			clearInterval(pollingInterval);
+		}
+	});
+
+	async function loadModules(silent = false) {
+		try {
+			if (!silent) loading = true;
+			// Without serverId, it fetches all modules
+			const response = await rpcClient.module.listModules({}, silent ? silentCallOptions : undefined);
+			modules = response.modules;
+		} catch {
+			if (!silent) toast.error('Failed to load modules');
+		} finally {
+			if (!silent) loading = false;
+		}
+	}
+
+	async function handleStartModule(module: Module) {
+		actionLoading = module.id;
+		try {
+			await rpcClient.module.startModule({ id: module.id });
+			toast.success(`Starting ${module.name}...`);
+			await loadModules(true);
+		} catch (error) {
+			toast.error(`Failed to start module: ${error instanceof Error ? error.message : 'Unknown error'}`);
+		} finally {
+			actionLoading = null;
+		}
+	}
+
+	async function handleStopModule(module: Module) {
+		actionLoading = module.id;
+		try {
+			await rpcClient.module.stopModule({ id: module.id });
+			toast.success(`Stopping ${module.name}...`);
+			await loadModules(true);
+		} catch (error) {
+			toast.error(`Failed to stop module: ${error instanceof Error ? error.message : 'Unknown error'}`);
+		} finally {
+			actionLoading = null;
+		}
+	}
+
+	async function handleRestartModule(module: Module) {
+		actionLoading = module.id;
+		try {
+			await rpcClient.module.restartModule({ id: module.id });
+			toast.success(`Restarting ${module.name}...`);
+			await loadModules(true);
+		} catch (error) {
+			toast.error(`Failed to restart module: ${error instanceof Error ? error.message : 'Unknown error'}`);
+		} finally {
+			actionLoading = null;
+		}
+	}
+
+	async function handleDeleteModule(module: Module) {
+		const confirmed = confirm(`Are you sure you want to delete "${module.name}"?\n\nThis will stop and remove the container and all module data.`);
+		if (!confirmed) return;
+
+		actionLoading = module.id;
+		try {
+			await rpcClient.module.deleteModule({ id: module.id });
+			toast.success(`Module "${module.name}" deleted`);
+			await loadModules(true);
+		} catch (error) {
+			toast.error(`Failed to delete module: ${error instanceof Error ? error.message : 'Unknown error'}`);
+		} finally {
+			actionLoading = null;
+		}
+	}
+
+	function openEditDialog(module: Module) {
+		selectedModule = module;
+		editDialogOpen = true;
+	}
+
+	function openLogsDialog(module: Module) {
+		selectedModule = module;
+		logsDialogOpen = true;
+	}
+
+	function getStatusBadgeVariant(status: ModuleStatus): 'default' | 'secondary' | 'destructive' | 'outline' {
+		switch (status) {
+			case ModuleStatus.RUNNING: return 'default';
+			case ModuleStatus.STARTING:
+			case ModuleStatus.STOPPING:
+			case ModuleStatus.CREATING: return 'secondary';
+			case ModuleStatus.ERROR: return 'destructive';
+			default: return 'outline';
+		}
+	}
+
+	function getStatusLabel(status: ModuleStatus): string {
+		switch (status) {
+			case ModuleStatus.RUNNING: return 'Running';
+			case ModuleStatus.STOPPED: return 'Stopped';
+			case ModuleStatus.STARTING: return 'Starting';
+			case ModuleStatus.STOPPING: return 'Stopping';
+			case ModuleStatus.ERROR: return 'Error';
+			case ModuleStatus.CREATING: return 'Creating';
+			default: return 'Unknown';
+		}
+	}
+</script>
+
+<div class="space-y-4">
+	<div class="flex items-center justify-between">
+		<div>
+			<h3 class="text-lg font-medium">Active Instances</h3>
+			<p class="text-sm text-muted-foreground">All modules running across all your servers.</p>
+		</div>
+		<Button variant="outline" size="sm" onclick={() => loadModules()} disabled={loading}>
+			{#if loading}
+				<Loader2 class="h-4 w-4 animate-spin" />
+			{:else}
+				<RefreshCw class="h-4 w-4" />
+			{/if}
+		</Button>
+	</div>
+
+	{#if loading && modules.length === 0}
+		<div class="flex items-center justify-center py-12">
+			<Loader2 class="h-8 w-8 animate-spin text-muted-foreground" />
+		</div>
+	{:else if modules.length === 0}
+		<div class="flex flex-col items-center justify-center py-12 text-center border rounded-lg bg-card">
+			<Package class="h-12 w-12 mb-4 text-muted-foreground/50" />
+			<h3 class="text-lg font-medium mb-1">No Active Modules</h3>
+			<p class="text-sm text-muted-foreground max-w-sm">
+				You don't have any modules running on any of your servers right now.
+			</p>
+		</div>
+	{:else}
+		<div class="grid gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+			{#each modules as module (module.id)}
+				{@const isLoading = actionLoading === module.id}
+				<Card class="group relative overflow-hidden border shadow-sm hover:shadow-md transition-all">
+					<div class="absolute top-0 left-0 right-0 h-1 {module.status === ModuleStatus.RUNNING ? 'bg-green-500' : module.status === ModuleStatus.ERROR ? 'bg-red-500' : 'bg-gray-300'}"></div>
+					<CardContent class="p-4">
+						<div class="flex items-start justify-between mb-3">
+							<div class="flex-1 min-w-0">
+								<div class="flex items-center gap-2 mb-1">
+									<h3 class="font-semibold truncate">{module.name}</h3>
+									<Badge variant={getStatusBadgeVariant(module.status)} class="text-xs">
+										{getStatusLabel(module.status)}
+									</Badge>
+								</div>
+								<div class="flex items-center gap-2 text-xs text-muted-foreground truncate">
+									<span class="flex items-center gap-1"><Server class="h-3 w-3" /> {module.serverName || module.serverId}</span>
+									<span>•</span>
+									<span class="truncate">{module.templateName}</span>
+								</div>
+							</div>
+							<div class="flex items-center gap-1 ml-2">
+								{#if module.status === ModuleStatus.STOPPED}
+									<Button
+										size="icon"
+										variant="ghost"
+										onclick={() => handleStartModule(module)}
+										disabled={isLoading}
+										title="Start module"
+										class="h-8 w-8"
+									>
+										{#if isLoading}
+											<Loader2 class="h-4 w-4 animate-spin" />
+										{:else}
+											<Play class="h-4 w-4 text-green-500" />
+										{/if}
+									</Button>
+								{:else if module.status === ModuleStatus.RUNNING}
+									<Button
+										size="icon"
+										variant="ghost"
+										onclick={() => handleStopModule(module)}
+										disabled={isLoading}
+										title="Stop module"
+										class="h-8 w-8"
+									>
+										{#if isLoading}
+											<Loader2 class="h-4 w-4 animate-spin" />
+										{:else}
+											<Square class="h-4 w-4 text-red-500" />
+										{/if}
+									</Button>
+									<Button
+										size="icon"
+										variant="ghost"
+										onclick={() => handleRestartModule(module)}
+										disabled={isLoading}
+										title="Restart module"
+										class="h-8 w-8"
+									>
+										<RotateCw class="h-4 w-4" />
+									</Button>
+								{:else if module.status === ModuleStatus.STARTING || module.status === ModuleStatus.STOPPING || module.status === ModuleStatus.CREATING}
+									<Button size="icon" variant="ghost" disabled class="h-8 w-8">
+										<Loader2 class="h-4 w-4 animate-spin" />
+									</Button>
+								{:else if module.status === ModuleStatus.ERROR}
+									<Button
+										size="icon"
+										variant="ghost"
+										onclick={() => handleStartModule(module)}
+										disabled={isLoading}
+										title="Start module"
+										class="h-8 w-8"
+									>
+										{#if isLoading}
+											<Loader2 class="h-4 w-4 animate-spin" />
+										{:else}
+											<Play class="h-4 w-4 text-green-500" />
+										{/if}
+									</Button>
+								{/if}
+							</div>
+						</div>
+
+						<div class="text-xs mb-3 space-y-1">
+							{#if module.status === ModuleStatus.RUNNING && module.memoryUsage > 0}
+								<div class="flex items-center gap-3 text-muted-foreground">
+									<span><Cpu class="h-3 w-3 inline mr-1" />{module.memoryUsage.toFixed(0)} MB</span>
+									<span>CPU: {module.cpuPercent.toFixed(1)}%</span>
+								</div>
+							{:else}
+								<div class="text-muted-foreground/60 invisible flex items-center gap-3">
+									<span><Cpu class="h-3 w-3 inline mr-1" />0 MB</span>
+								</div>
+							{/if}
+						</div>
+
+						<div class="flex items-center justify-between pt-2 border-t">
+							<div class="flex items-center gap-1">
+								{#if module.autoStart}
+									<Badge variant="secondary" class="text-[10px] px-1.5 py-0">Auto-start</Badge>
+								{/if}
+							</div>
+							<div class="flex items-center gap-1">
+								<Button
+									size="icon"
+									variant="ghost"
+									onclick={() => openLogsDialog(module)}
+									title="View logs"
+									class="h-7 w-7"
+								>
+									<Terminal class="h-3.5 w-3.5" />
+								</Button>
+								<Button
+									size="icon"
+									variant="ghost"
+									onclick={() => openEditDialog(module)}
+									title="Edit module"
+									class="h-7 w-7"
+								>
+									<Settings class="h-3.5 w-3.5" />
+								</Button>
+								<Button
+									size="icon"
+									variant="ghost"
+									onclick={() => handleDeleteModule(module)}
+									disabled={isLoading}
+									title="Delete module"
+									class="h-7 w-7 text-destructive hover:text-destructive"
+								>
+									<Trash2 class="h-3.5 w-3.5" />
+								</Button>
+							</div>
+						</div>
+					</CardContent>
+				</Card>
+			{/each}
+		</div>
+	{/if}
+</div>
+
+{#if selectedModule}
+	<ModuleDialog
+		bind:open={editDialogOpen}
+		mode="edit"
+		module={selectedModule}
+		onSuccess={() => loadModules(true)}
+	/>
+
+	<ModuleLogsDialog
+		bind:open={logsDialogOpen}
+		module={selectedModule}
+	/>
+{/if}

--- a/web/discopanel/src/routes/modules/TemplateManagement.svelte
+++ b/web/discopanel/src/routes/modules/TemplateManagement.svelte
@@ -1,0 +1,210 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button';
+	import { Card, CardContent } from '$lib/components/ui/card';
+	import { Badge } from '$lib/components/ui/badge';
+	import DynamicIcon from '$lib/components/ui/DynamicIcon.svelte';
+	import { rpcClient } from '$lib/api/rpc-client';
+	import { toast } from 'svelte-sonner';
+	import type { ModuleTemplate } from '$lib/proto/discopanel/v1/module_pb';
+	import { ModuleTemplateType } from '$lib/proto/discopanel/v1/module_pb';
+	import { Loader2, Plus, Trash2, Settings, Package, RefreshCw, Layers } from '@lucide/svelte';
+	import ModuleTemplateCreateDialog from '$lib/components/server/ModuleTemplateCreateDialog.svelte';
+	import { onMount } from 'svelte';
+
+	let templates = $state<ModuleTemplate[]>([]);
+	let loading = $state(true);
+
+	// Dialog state
+	let createDialogOpen = $state(false);
+	let editDialogOpen = $state(false);
+	let selectedTemplate = $state<ModuleTemplate | null>(null);
+
+	onMount(() => {
+		loadTemplates();
+	});
+
+	async function loadTemplates(silent = false) {
+		try {
+			if (!silent) loading = true;
+			const response = await rpcClient.module.listModuleTemplates({});
+			templates = response.templates;
+		} catch {
+			if (!silent) toast.error('Failed to load module templates');
+		} finally {
+			if (!silent) loading = false;
+		}
+	}
+
+	async function handleDeleteTemplate(template: ModuleTemplate) {
+		const confirmed = confirm(`Are you sure you want to delete template "${template.name}"?\n\nThis cannot be undone and will not affect existing instances.`);
+		if (!confirmed) return;
+
+		try {
+			await rpcClient.module.deleteModuleTemplate({ id: template.id });
+			toast.success(`Template "${template.name}" deleted`);
+			await loadTemplates(true);
+		} catch (error) {
+			toast.error(`Failed to delete template: ${error instanceof Error ? error.message : 'Unknown error'}`);
+		}
+	}
+
+	function openEditDialog(template: ModuleTemplate) {
+		selectedTemplate = template;
+		editDialogOpen = true;
+	}
+
+	let categories = $derived.by(() => {
+		const cats = new Set<string>();
+		templates.forEach((t) => {
+			if (t.category) cats.add(t.category);
+		});
+		return Array.from(cats).sort();
+	});
+
+	let selectedCategory = $state<string | null>(null);
+
+	let filteredTemplates = $derived.by(() => {
+		if (!selectedCategory) return templates;
+		return templates.filter((t) => t.category === selectedCategory);
+	});
+</script>
+
+<div class="space-y-6">
+	<div class="flex items-center justify-between">
+		<div>
+			<h3 class="text-lg font-medium">Module Templates</h3>
+			<p class="text-sm text-muted-foreground">Manage blueprints for creating module instances.</p>
+		</div>
+		<div class="flex items-center gap-2">
+			<Button variant="outline" size="sm" onclick={() => loadTemplates()} disabled={loading}>
+				{#if loading}
+					<Loader2 class="h-4 w-4 animate-spin" />
+				{:else}
+					<RefreshCw class="h-4 w-4" />
+				{/if}
+			</Button>
+			<Button onclick={() => (createDialogOpen = true)}>
+				<Plus class="h-4 w-4 mr-2" />
+				Create Template
+			</Button>
+		</div>
+	</div>
+
+	{#if categories.length > 0}
+		<div class="flex flex-wrap gap-2">
+			<Button
+				variant={selectedCategory === null ? 'default' : 'outline'}
+				size="sm"
+				onclick={() => (selectedCategory = null)}
+				class="h-8 px-3"
+			>
+				All
+			</Button>
+			{#each categories as cat (cat)}
+				<Button
+					variant={selectedCategory === cat ? 'default' : 'outline'}
+					size="sm"
+					onclick={() => (selectedCategory = cat)}
+					class="h-8 px-3"
+				>
+					{cat}
+				</Button>
+			{/each}
+		</div>
+	{/if}
+
+	{#if loading && templates.length === 0}
+		<div class="flex items-center justify-center py-12">
+			<Loader2 class="h-8 w-8 animate-spin text-muted-foreground" />
+		</div>
+	{:else if templates.length === 0}
+		<div class="flex flex-col items-center justify-center py-12 text-center border rounded-lg bg-card">
+			<Layers class="h-12 w-12 mb-4 text-muted-foreground/50" />
+			<h3 class="text-lg font-medium mb-1">No Templates Found</h3>
+			<p class="text-sm text-muted-foreground max-w-sm mb-4">
+				You don't have any module templates configured yet.
+			</p>
+			<Button onclick={() => (createDialogOpen = true)}>
+				<Plus class="h-4 w-4 mr-2" />
+				Create Template
+			</Button>
+		</div>
+	{:else}
+		<div class="grid gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+			{#each filteredTemplates as template (template.name)}
+				<Card class="group relative overflow-hidden border shadow-sm hover:shadow-md transition-all">
+					<CardContent class="p-5 flex flex-col h-full">
+						<div class="flex items-start gap-4 mb-4">
+							<div class="h-12 w-12 rounded-xl bg-primary/10 flex items-center justify-center shrink-0">
+								<DynamicIcon name={template.icon} class="h-6 w-6 text-primary" fallback="Package" />
+							</div>
+							<div class="flex-1 min-w-0">
+								<h3 class="font-semibold truncate text-lg">{template.name}</h3>
+								<div class="flex items-center gap-2 mt-1 flex-wrap">
+									{#if template.type === ModuleTemplateType.BUILTIN}
+										<Badge variant="default" class="text-[10px] px-1.5 py-0">Built-in</Badge>
+									{:else}
+										<Badge variant="outline" class="text-[10px] px-1.5 py-0">Custom</Badge>
+									{/if}
+									{#if template.category}
+										<Badge variant="secondary" class="text-[10px] px-1.5 py-0">{template.category}</Badge>
+									{/if}
+								</div>
+							</div>
+						</div>
+						
+						<p class="text-sm text-muted-foreground flex-1 mb-4 line-clamp-2">
+							{template.description || 'No description provided'}
+						</p>
+
+						<div class="flex items-center justify-between pt-4 border-t mt-auto">
+							<div class="text-xs text-muted-foreground font-mono truncate max-w-[150px]">
+								{template.dockerImage}
+							</div>
+							
+							{#if template.type === ModuleTemplateType.CUSTOM}
+								<div class="flex items-center gap-1">
+									<Button
+										size="icon"
+										variant="ghost"
+										onclick={() => openEditDialog(template)}
+										title="Edit template"
+										class="h-8 w-8"
+									>
+										<Settings class="h-4 w-4" />
+									</Button>
+									<Button
+										size="icon"
+										variant="ghost"
+										onclick={() => handleDeleteTemplate(template)}
+										title="Delete template"
+										class="h-8 w-8 text-destructive hover:text-destructive"
+									>
+										<Trash2 class="h-4 w-4" />
+									</Button>
+								</div>
+							{:else}
+								<div class="text-xs text-muted-foreground/50 px-2 py-1 bg-muted rounded">Read-only</div>
+							{/if}
+						</div>
+					</CardContent>
+				</Card>
+			{/each}
+		</div>
+	{/if}
+</div>
+
+<ModuleTemplateCreateDialog
+	bind:open={createDialogOpen}
+	mode="create"
+	onSuccess={() => loadTemplates(true)}
+/>
+
+{#if selectedTemplate}
+	<ModuleTemplateCreateDialog
+		bind:open={editDialogOpen}
+		mode="edit"
+		template={selectedTemplate}
+		onSuccess={() => loadTemplates(true)}
+	/>
+{/if}


### PR DESCRIPTION
This adds support for specifying `docker.labels` in the config.yaml as yaml in addition to using an string object

**Before:**
```yaml
docker:
  labels: '{ "com.example.enable": "true", "com.example.test": "123" }'
```

**After:**
```yaml
docker:
  labels: 
    com.example.enable: true
    com.example.test: 123
```
or even
```yaml
docker:
  labels:
    com:
      example:
        enable: true
        test: 123
        test1: "1234"
```