### PR TITLE
removed 200px limit for files

### DIFF
--- a/web/discopanel/src/lib/components/files/server-files.svelte
+++ b/web/discopanel/src/lib/components/files/server-files.svelte
@@ -796,7 +796,7 @@
 	});
 </script>
 
-<div bind:this={containerEl} class="flex flex-col border rounded-lg overflow-hidden bg-background" style={heightStyle}>
+<div bind:this={containerEl} class="flex flex-col border rounded-lg overflow-hidden bg-background">
 	<!-- Toolbar -->
 	<FileToolbar
 		{filterText}


### PR DESCRIPTION
Removed the hardcoded `heightStyle` from being applied to files tab div.

This constraint doesn't exist on any other tab, making the files tab noticeably cramped and harder to work with:
<img width="1470" height="388" alt="Screenshot 2026-05-02 at 11 28 17" src="https://github.com/user-attachments/assets/0f703a21-a88c-48c7-8691-f29c41a066fa" />

The config tab, for example, has no such restriction and renders at full height:
<img width="606" height="400" alt="Screenshot 2026-05-02 at 11 28 39" src="https://github.com/user-attachments/assets/3baf69d6-5e60-48b1-ab88-2af6f15d03a6" />

After the fix, the files tab behaves consistently with the rest:
<img width="606" height="400" alt="Screenshot 2026-05-02 at 11 29 08" src="https://github.com/user-attachments/assets/2a69c086-2544-4912-94bc-cf8fd34c56c3" />