### PR TITLE
Feat: commands via rcon

### DIFF
--- a/cmd/discopanel/main.go
+++ b/cmd/discopanel/main.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/nickheyer/discopanel/internal/command"
 	"github.com/nickheyer/discopanel/internal/config"
 	storage "github.com/nickheyer/discopanel/internal/db"
 	"github.com/nickheyer/discopanel/internal/docker"
@@ -158,8 +159,11 @@ func main() {
 	}
 	defer proxyManager.Stop()
 
+	// Initialize command sender
+	sender := command.NewSender(store, cfg, dockerClient)
+
 	// Initialize task scheduler
-	taskScheduler := scheduler.NewScheduler(store, dockerClient, log, scheduler.Config{
+	taskScheduler := scheduler.NewScheduler(store, dockerClient, sender, log, scheduler.Config{
 		CheckInterval: time.Duration(cfg.Docker.SyncInterval) * time.Second, // Use same interval as container status monitor
 	})
 
@@ -170,7 +174,7 @@ func main() {
 	defer taskScheduler.Stop()
 
 	// Initialize metrics collector
-	metricsCollector := metrics.NewCollector(store, dockerClient, cfg, log)
+	metricsCollector := metrics.NewCollector(store, dockerClient, sender, cfg, log)
 	if err := metricsCollector.Start(); err != nil {
 		log.Error("Failed to start metrics collector: %v", err)
 	}
@@ -189,7 +193,7 @@ func main() {
 	defer moduleManager.Stop()
 
 	// Initialize RPC server with full configuration
-	rpcServer := rpc.NewServer(store, dockerClient, cfg, proxyManager, taskScheduler, metricsCollector, moduleManager, log)
+	rpcServer := rpc.NewServer(store, dockerClient, sender, cfg, proxyManager, taskScheduler, metricsCollector, moduleManager, log)
 
 	// Print recovery key
 	if key := rpcServer.RecoveryKey(); key != "" {

--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
+	github.com/jltobler/go-rcon v0.3.0
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/klauspost/pgzip v1.2.6 // indirect
 	github.com/mattn/go-sqlite3 v1.14.30 // indirect

--- a/go.sum
+++ b/go.sum
@@ -212,6 +212,8 @@ github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/jltobler/go-rcon v0.3.0 h1:iaa4bLak3MAuIIpGJb5j05x+XazPMJklWHmTUbpT3SM=
+github.com/jltobler/go-rcon v0.3.0/go.mod h1:pBX1cDeqcs0QZTy2nffNreX0CyjGxU6AIXGbK83RKSs=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/internal/command/sender.go
+++ b/internal/command/sender.go
@@ -1,0 +1,107 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/nickheyer/discopanel/internal/config"
+	storage "github.com/nickheyer/discopanel/internal/db"
+	"github.com/nickheyer/discopanel/internal/proxy"
+	rcon "github.com/nickheyer/discopanel/internal/rcon"
+)
+
+type DockerExecutor interface {
+	ExecCommand(ctx context.Context, containerID string, command string) (string, error)
+}
+
+type Sender struct {
+	store  *storage.Store
+	config *config.Config
+	docker DockerExecutor
+}
+
+func NewSender(store *storage.Store, cfg *config.Config, docker DockerExecutor) *Sender {
+	return &Sender{
+		store:  store,
+		config: cfg,
+		docker: docker,
+	}
+}
+
+func (s *Sender) SendCommand(ctx context.Context, serverID string, command string) (string, error) {
+	server, err := s.store.GetServer(ctx, serverID)
+
+	if err != nil {
+		return "", fmt.Errorf("server container not found")
+	}
+	if server.ContainerID == "" {
+		return "", fmt.Errorf("server container not found")
+	}
+
+	// old docker exec command
+	dockerExec := func(cause error) (string, error) {
+		output, err := s.docker.ExecCommand(ctx, server.ContainerID, command)
+		if err != nil {
+			return "", fmt.Errorf("rcon path failed: %w; fallback exec failed: %v", cause, err)
+		}
+		return output, nil
+	}
+
+	serverCfg, err := s.store.GetServerConfig(ctx, serverID)
+	if err != nil {
+		return dockerExec(fmt.Errorf("failed to load server config: %w", err))
+	}
+
+	if serverCfg.EnableRCON != nil && *serverCfg.EnableRCON == false {
+		return dockerExec(fmt.Errorf("rcon is disabled for this server"))
+	}
+
+	var rconPort int
+	if v, ok := s.config.Minecraft.GlobalConfig["rconPort"]; ok && v != nil {
+		switch t := v.(type) {
+		case int:
+			rconPort = t
+		case int64:
+			rconPort = int(t)
+		case float64:
+			rconPort = int(t)
+		case string:
+			if p, err := strconv.Atoi(t); err == nil {
+				rconPort = p
+			}
+		}
+	}
+	if serverCfg.RCONPort != nil {
+		rconPort = *serverCfg.RCONPort
+	}
+
+	var rconPassword string
+	if v, ok := s.config.Minecraft.GlobalConfig["rconPassword"]; ok && v != nil {
+		if p, ok := v.(string); ok {
+			rconPassword = p
+		} else {
+			rconPassword = fmt.Sprint(v)
+		}
+	}
+	if serverCfg.RCONPassword != nil {
+		rconPassword = *serverCfg.RCONPassword
+	}
+
+	ip, err := proxy.GetContainerIP(server.ContainerID, s.config.Docker.NetworkName)
+	if err != nil {
+		return dockerExec(fmt.Errorf("failed to resolve container ip: %w", err))
+	}
+
+	// run comamand in dedicated context with timeout
+	rconCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+	output, err := rcon.SendCommand(rconCtx, ip, rconPort, rconPassword, command)
+
+	if err != nil {
+		return dockerExec(fmt.Errorf("rcon command failed: %w", err))
+	}
+
+	return output, nil
+}

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/nickheyer/discopanel/internal/command"
 	"github.com/nickheyer/discopanel/internal/config"
 	storage "github.com/nickheyer/discopanel/internal/db"
 	"github.com/nickheyer/discopanel/internal/docker"
@@ -65,6 +66,7 @@ func DefaultConfig() CollectorConfig {
 type Collector struct {
 	store  *storage.Store
 	docker *docker.Client
+	sender *command.Sender
 	config *config.Config
 	log    *logger.Logger
 
@@ -79,7 +81,7 @@ type Collector struct {
 }
 
 // Creates a new metrics collector
-func NewCollector(store *storage.Store, docker *docker.Client, cfg *config.Config, log *logger.Logger, collectorCfg ...CollectorConfig) *Collector {
+func NewCollector(store *storage.Store, docker *docker.Client, sender *command.Sender, cfg *config.Config, log *logger.Logger, collectorCfg ...CollectorConfig) *Collector {
 	cc := DefaultConfig()
 	if len(collectorCfg) > 0 {
 		cc = collectorCfg[0]
@@ -88,6 +90,7 @@ func NewCollector(store *storage.Store, docker *docker.Client, cfg *config.Confi
 	return &Collector{
 		store:           store,
 		docker:          docker,
+		sender:          sender,
 		config:          cfg,
 		log:             log,
 		metrics:         make(map[string]*ServerMetrics),
@@ -282,7 +285,7 @@ func (c *Collector) collectRCONData() {
 
 		// Get player count from RCON
 		if !slpHasPlayerData {
-			output, err := c.docker.ExecCommand(ctx, server.ContainerID, "list")
+			output, err := c.sender.SendCommand(ctx, server.ID, "list")
 			if err == nil && output != "" {
 				count, _ := minecraft.ParsePlayerListFromOutput(output)
 				c.updateMetrics(server.ID, func(m *ServerMetrics) {
@@ -299,7 +302,7 @@ func (c *Collector) collectRCONData() {
 				if cmd == "" {
 					continue
 				}
-				output, err := c.docker.ExecCommand(ctx, server.ContainerID, cmd)
+				output, err := c.sender.SendCommand(ctx, server.ID, cmd)
 				if err == nil && output != "" {
 					tps := minecraft.ParseTPSFromOutput(output)
 					if tps > 0 {

--- a/internal/module/events.go
+++ b/internal/module/events.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/nickheyer/discopanel/internal/alias"
+	"github.com/nickheyer/discopanel/internal/command"
 	storage "github.com/nickheyer/discopanel/internal/db"
 	"github.com/nickheyer/discopanel/internal/docker"
 	"github.com/nickheyer/discopanel/pkg/logger"
@@ -18,15 +19,17 @@ type EventDispatcher struct {
 	manager *Manager
 	store   *storage.Store
 	docker  *docker.Client
+	sender  *command.Sender
 	logger  *logger.Logger
 }
 
 // NewEventDispatcher creates a new event dispatcher
-func NewEventDispatcher(manager *Manager, store *storage.Store, docker *docker.Client, log *logger.Logger) *EventDispatcher {
+func NewEventDispatcher(manager *Manager, store *storage.Store, docker *docker.Client, sender *command.Sender, log *logger.Logger) *EventDispatcher {
 	return &EventDispatcher{
 		manager: manager,
 		store:   store,
 		docker:  docker,
+		sender:  sender,
 		logger:  log,
 	}
 }
@@ -140,8 +143,8 @@ func (d *EventDispatcher) sendRCON(ctx context.Context, serverID string, command
 		return nil
 	}
 
-	// Use ExecCommand which runs rcon-cli inside the server container
-	_, err = d.docker.ExecCommand(ctx, server.ContainerID, command)
+	// send command
+	_, err = d.sender.SendCommand(ctx, server.ID, command)
 	return err
 }
 

--- a/internal/rcon/rcon.go
+++ b/internal/rcon/rcon.go
@@ -1,0 +1,36 @@
+package rcon
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jltobler/go-rcon"
+)
+
+type rconResult struct {
+	output string
+	err    error
+}
+
+func SendCommand(ctx context.Context, RCONHost string, RCONPort int, RCONPassword string, command string) (string, error) {
+	// initialize Client
+	rconClient := rcon.NewClient(fmt.Sprintf("rcon://%s:%d", RCONHost, RCONPort), RCONPassword)
+
+	// run Command in a goroutine to allow for timeout handling
+	resultCh := make(chan rconResult, 1)
+	go func() {
+		output, sendErr := rconClient.Send(command)
+		resultCh <- rconResult{output: output, err: sendErr}
+	}()
+
+	// wait for either the command result or a timeout
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	case result := <-resultCh:
+		if result.err != nil {
+			return "", result.err
+		}
+		return result.output, nil
+	}
+}

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -10,6 +10,7 @@ import (
 	"connectrpc.com/connect"
 	"connectrpc.com/grpcreflect"
 	"github.com/nickheyer/discopanel/internal/auth"
+	"github.com/nickheyer/discopanel/internal/command"
 	"github.com/nickheyer/discopanel/internal/config"
 	storage "github.com/nickheyer/discopanel/internal/db"
 	"github.com/nickheyer/discopanel/internal/docker"
@@ -36,6 +37,7 @@ import (
 type Server struct {
 	store            *storage.Store
 	docker           *docker.Client
+	sender           *command.Sender
 	config           *config.Config
 	log              *logger.Logger
 	handler          http.Handler
@@ -53,7 +55,7 @@ type Server struct {
 }
 
 // Creates new Connect RPC server
-func NewServer(store *storage.Store, docker *docker.Client, cfg *config.Config, proxyManager *proxy.Manager, sched *scheduler.Scheduler, metricsCollector *metrics.Collector, moduleManager *module.Manager, log *logger.Logger) *Server {
+func NewServer(store *storage.Store, docker *docker.Client, sender *command.Sender, cfg *config.Config, proxyManager *proxy.Manager, sched *scheduler.Scheduler, metricsCollector *metrics.Collector, moduleManager *module.Manager, log *logger.Logger) *Server {
 	// Initialize RBAC enforcer
 	enforcer, err := rbac.NewEnforcer(store.DB())
 	if err != nil {
@@ -90,12 +92,13 @@ func NewServer(store *storage.Store, docker *docker.Client, cfg *config.Config, 
 	downloadManager := download.NewManager(cfg.Storage.TempDir, uploadTTL, log)
 
 	// Initialize WebSocket hub
-	wsHub := ws.NewHub(logStreamer, authManager, enforcer, store, docker, log)
+	wsHub := ws.NewHub(logStreamer, authManager, enforcer, store, docker, sender, log)
 	go wsHub.Run()
 
 	s := &Server{
 		store:            store,
 		docker:           docker,
+		sender:           sender,
 		config:           cfg,
 		log:              log,
 		proxyManager:     proxyManager,
@@ -191,7 +194,7 @@ func (s *Server) registerServices(mux *http.ServeMux, opts []connect.HandlerOpti
 	modService := services.NewModService(s.store, s.docker, s.uploadManager, s.log)
 	modpackService := services.NewModpackService(s.store, s.config, s.uploadManager, s.log)
 	proxyService := services.NewProxyService(s.store, s.docker, s.proxyManager, s.config, s.logStreamer, s.log)
-	serverService := services.NewServerService(s.store, s.docker, s.config, s.proxyManager, s.logStreamer, s.metricsCollector, s.moduleManager, s.log)
+	serverService := services.NewServerService(s.store, s.docker, s.sender, s.config, s.proxyManager, s.logStreamer, s.metricsCollector, s.moduleManager, s.log)
 	supportService := services.NewSupportService(s.store, s.docker, s.config, s.log)
 	taskService := services.NewTaskService(s.store, s.scheduler, s.log)
 	userService := services.NewUserService(s.store, s.authManager, s.log)

--- a/internal/rpc/services/server.go
+++ b/internal/rpc/services/server.go
@@ -16,6 +16,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
+	"github.com/nickheyer/discopanel/internal/command"
 	"github.com/nickheyer/discopanel/internal/config"
 	storage "github.com/nickheyer/discopanel/internal/db"
 	"github.com/nickheyer/discopanel/internal/docker"
@@ -37,6 +38,7 @@ var _ discopanelv1connect.ServerServiceHandler = (*ServerService)(nil)
 type ServerService struct {
 	store            *storage.Store
 	docker           *docker.Client
+	sender           *command.Sender
 	config           *config.Config
 	proxy            *proxy.Manager
 	log              *logger.Logger
@@ -46,10 +48,11 @@ type ServerService struct {
 }
 
 // NewServerService creates a new server service
-func NewServerService(store *storage.Store, docker *docker.Client, config *config.Config, proxy *proxy.Manager, logStreamer *logger.LogStreamer, metricsCollector *metrics.Collector, moduleManager *module.Manager, log *logger.Logger) *ServerService {
+func NewServerService(store *storage.Store, docker *docker.Client, sender *command.Sender, config *config.Config, proxy *proxy.Manager, logStreamer *logger.LogStreamer, metricsCollector *metrics.Collector, moduleManager *module.Manager, log *logger.Logger) *ServerService {
 	return &ServerService{
 		store:            store,
 		docker:           docker,
+		sender:           sender,
 		config:           config,
 		proxy:            proxy,
 		log:              log,
@@ -1325,6 +1328,12 @@ func (s *ServerService) RecreateServer(ctx context.Context, req *connect.Request
 // SendCommand sends a command to a server
 func (s *ServerService) SendCommand(ctx context.Context, req *connect.Request[v1.SendCommandRequest]) (*connect.Response[v1.SendCommandResponse], error) {
 	server, err := s.store.GetServer(ctx, req.Msg.Id)
+
+	silent := false
+	if req.Msg.Silent != nil {
+		silent = *req.Msg.Silent
+	}
+
 	if err != nil {
 		s.log.Error("Failed to get server: %v", err)
 		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("server not found"))
@@ -1346,16 +1355,16 @@ func (s *ServerService) SendCommand(ctx context.Context, req *connect.Request[v1
 
 	// Add command to log stream if available
 	commandTime := time.Now()
-	if s.logStreamer != nil {
+	if !silent && s.logStreamer != nil {
 		s.logStreamer.AddCommandEntry(server.ContainerID, req.Msg.Command, commandTime)
 	}
 
-	// Execute command in container
-	output, err := s.docker.ExecCommand(ctx, server.ContainerID, req.Msg.Command)
+	// Send command
+	output, err := s.sender.SendCommand(ctx, server.ID, req.Msg.Command)
 	success := err == nil
 
 	// Add command output to log stream if available
-	if s.logStreamer != nil && (output != "" || !success) {
+	if !silent && s.logStreamer != nil && (output != "" || !success) {
 		s.logStreamer.AddCommandOutput(server.ContainerID, output, success, commandTime)
 	}
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/robfig/cron/v3"
 
+	"github.com/nickheyer/discopanel/internal/command"
 	storage "github.com/nickheyer/discopanel/internal/db"
 	"github.com/nickheyer/discopanel/internal/docker"
 	"github.com/nickheyer/discopanel/pkg/logger"
@@ -19,6 +20,7 @@ import (
 type Scheduler struct {
 	store         *storage.Store
 	docker        *docker.Client
+	sender        *command.Sender
 	log           *logger.Logger
 	checkInterval time.Duration
 
@@ -53,7 +55,7 @@ func DefaultConfig() Config {
 }
 
 // NewScheduler creates a new task scheduler
-func NewScheduler(store *storage.Store, docker *docker.Client, log *logger.Logger, config ...Config) *Scheduler {
+func NewScheduler(store *storage.Store, docker *docker.Client, sender *command.Sender, log *logger.Logger, config ...Config) *Scheduler {
 	cfg := DefaultConfig()
 	if len(config) > 0 {
 		cfg = config[0]
@@ -62,6 +64,7 @@ func NewScheduler(store *storage.Store, docker *docker.Client, log *logger.Logge
 	return &Scheduler{
 		store:             store,
 		docker:            docker,
+		sender:            sender,
 		log:               log,
 		checkInterval:     cfg.CheckInterval,
 		stopChan:          make(chan struct{}),
@@ -403,7 +406,7 @@ func (s *Scheduler) executeCommandTask(ctx context.Context, server *storage.Serv
 		return "", fmt.Errorf("server has no container")
 	}
 
-	output, err := s.docker.ExecCommand(ctx, server.ContainerID, config.Command)
+	output, err := s.sender.SendCommand(ctx, server.ID, config.Command)
 	return output, err
 }
 

--- a/internal/ws/hub.go
+++ b/internal/ws/hub.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/nickheyer/discopanel/internal/auth"
+	"github.com/nickheyer/discopanel/internal/command"
 	storage "github.com/nickheyer/discopanel/internal/db"
 	"github.com/nickheyer/discopanel/internal/docker"
 	"github.com/nickheyer/discopanel/internal/rbac"
@@ -39,6 +40,7 @@ type Hub struct {
 	store       *storage.Store
 	docker      *docker.Client
 	log         *logger.Logger
+	sender      *command.Sender
 
 	upgrader websocket.Upgrader
 
@@ -67,7 +69,7 @@ type Client struct {
 }
 
 // NewHub creates a new WebSocket hub
-func NewHub(logStreamer *logger.LogStreamer, authManager *auth.Manager, enforcer *rbac.Enforcer, store *storage.Store, docker *docker.Client, log *logger.Logger) *Hub {
+func NewHub(logStreamer *logger.LogStreamer, authManager *auth.Manager, enforcer *rbac.Enforcer, store *storage.Store, docker *docker.Client, sender *command.Sender, log *logger.Logger) *Hub {
 	return &Hub{
 		logStreamer: logStreamer,
 		authManager: authManager,
@@ -75,6 +77,7 @@ func NewHub(logStreamer *logger.LogStreamer, authManager *auth.Manager, enforcer
 		store:       store,
 		docker:      docker,
 		log:         log,
+		sender:      sender,
 		upgrader: websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool {
 				return true // Allow all origins (CORS handled elsewhere)
@@ -377,6 +380,11 @@ func (c *Client) handleCommand(msg *v1.CommandMessage) {
 		return
 	}
 
+	silent := false
+	if msg.Silent != nil {
+		silent = *msg.Silent
+	}
+
 	// Check command permission
 	if c.hub.enforcer != nil && c.user != nil {
 		allowed, err := c.hub.enforcer.Enforce(c.user.Roles, rbac.ResourceServers, rbac.ActionCommand, msg.ServerId)
@@ -405,16 +413,17 @@ func (c *Client) handleCommand(msg *v1.CommandMessage) {
 		return
 	}
 
-	// Add command to log stream
+	// Add command to log stream if not silent
 	commandTime := time.Now()
-	c.hub.logStreamer.AddCommandEntry(server.ContainerID, msg.Command, commandTime)
+	if !silent {
+		c.hub.logStreamer.AddCommandEntry(server.ContainerID, msg.Command, commandTime)
+	}
 
-	// Execute command
-	output, err := c.hub.docker.ExecCommand(ctx, server.ContainerID, msg.Command)
+	output, err := c.hub.sender.SendCommand(ctx, server.ID, msg.Command)
 	success := err == nil
 
-	// Add output to log stream
-	if output != "" || !success {
+	// Add output to log stream if not silent
+	if !silent && (output != "" || !success) {
 		c.hub.logStreamer.AddCommandOutput(server.ContainerID, output, success, commandTime)
 	}
 

--- a/proto/discopanel/v1/server.proto
+++ b/proto/discopanel/v1/server.proto
@@ -208,6 +208,7 @@ message RecreateServerResponse {
 message SendCommandRequest {
   string id = 1;
   string command = 2;
+  optional bool silent = 3;
 }
 
 // Command execution result

--- a/proto/discopanel/v1/websocket.proto
+++ b/proto/discopanel/v1/websocket.proto
@@ -75,6 +75,7 @@ message UnsubscribeMessage {
 message CommandMessage {
   string server_id = 1;
   string command = 2;
+  optional bool silent = 3;
 }
 
 // Auth success


### PR DESCRIPTION
This PR rewrites command handling.

Instead of using docker.exec, we now use [jltobler's Rcon Implementation](https://github.com/jltobler/go-rcon) in order to connect directly to the Minecraft server via RCON Protocoll over TCP.

docker.exec is still being used as fallback, when either RCON is disabled for the Minecraft server or RCON fails for whatever reason.

I decided to use jltobler's implementation since it is basically the only one I could find supporting multi packets and we gonna need them for future command completion functionality by retrieving and parsing help output, which is for vanilla servers above the maximum packet length of 4096 Bytes.

In preparation for command completion I also added an optional boolean field "silent" to the RPC SendCommand (and WebSocket for consistency), so commands and their output can be sent in background without appearing in the server console.

By default, if silent is not set, commands and their output are always logged into the console.