### PR TITLE
[Fix] Rcon Rewrite

### DIFF
--- a/cmd/discopanel/main.go
+++ b/cmd/discopanel/main.go
@@ -162,7 +162,7 @@ func main() {
 	defer proxyManager.Stop()
 
 	// Initialize command sender
-	sender := command.NewSender(store, cfg, dockerClient)
+	sender := command.NewSender(store, cfg, dockerClient, log)
 
 	// Initialize the central event bus
 	eventBus := events.NewBus(log)
@@ -371,6 +371,9 @@ func main() {
 
 	log.Info("Shutting down server...")
 	close(stopSessionCleanup)
+
+	// Closing all rcon connections
+	sender.CloseAll()
 
 	// Graceful shutdown with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/internal/command/sender.go
+++ b/internal/command/sender.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"time"
+	"sync"
 
 	"github.com/nickheyer/discopanel/internal/config"
 	storage "github.com/nickheyer/discopanel/internal/db"
 	"github.com/nickheyer/discopanel/internal/proxy"
 	rcon "github.com/nickheyer/discopanel/internal/rcon"
+	"github.com/nickheyer/discopanel/pkg/logger"
 )
 
 type DockerExecutor interface {
@@ -17,16 +18,21 @@ type DockerExecutor interface {
 }
 
 type Sender struct {
-	store  *storage.Store
-	config *config.Config
-	docker DockerExecutor
+	store   *storage.Store
+	config  *config.Config
+	docker  DockerExecutor
+	log     *logger.Logger
+	mu      sync.RWMutex
+	clients map[string]*rcon.Client
 }
 
-func NewSender(store *storage.Store, cfg *config.Config, docker DockerExecutor) *Sender {
+func NewSender(store *storage.Store, cfg *config.Config, docker DockerExecutor, log *logger.Logger) *Sender {
 	return &Sender{
-		store:  store,
-		config: cfg,
-		docker: docker,
+		store:   store,
+		config:  cfg,
+		docker:  docker,
+		log:     log,
+		clients: make(map[string]*rcon.Client),
 	}
 }
 
@@ -94,14 +100,70 @@ func (s *Sender) SendCommand(ctx context.Context, serverID string, command strin
 		return dockerExec(fmt.Errorf("failed to resolve container ip: %w", err))
 	}
 
-	// run comamand in dedicated context with timeout
-	rconCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
-	defer cancel()
-	output, err := rcon.SendCommand(rconCtx, ip, rconPort, rconPassword, command)
+	client, err := s.getOrCreateClient(serverID, ip, rconPort, rconPassword)
+	if err != nil {
+		return dockerExec(fmt.Errorf("failed to initialise rcon connection: %w", err))
+	}
+
+	output, err := client.Execute(command)
 
 	if err != nil {
+		fmt.Print(err)
+		s.Remove(serverID)
 		return dockerExec(fmt.Errorf("rcon command failed: %w", err))
 	}
 
 	return output, nil
+}
+
+func (s *Sender) getOrCreateClient(serverID string, host string, port int, password string) (*rcon.Client, error) {
+	s.mu.RLock()
+	client, exists := s.clients[serverID]
+	s.mu.RUnlock()
+
+	if exists {
+		if client.Host() == host && client.Port() == port && client.Password() == password {
+			return client, nil
+		}
+
+		s.Remove(serverID)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if client, exists = s.clients[serverID]; exists {
+		return client, nil
+	}
+
+	client = rcon.NewClient(host, port, password, s.log)
+
+	if err := client.Connect(); err != nil {
+		return nil, fmt.Errorf("failed to connect to server %s: %w", serverID, err)
+	}
+
+	s.clients[serverID] = client
+	return client, nil
+}
+
+func (s *Sender) Remove(serverID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if client, exists := s.clients[serverID]; exists {
+		_ = client.Close()
+		delete(s.clients, serverID)
+		s.log.Info("RCON connection removed for server %s", serverID)
+	}
+}
+
+func (s *Sender) CloseAll() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for id, client := range s.clients {
+		_ = client.Close()
+		delete(s.clients, id)
+	}
+	s.log.Info("RCON All connections closed")
 }

--- a/internal/rcon/rcon.go
+++ b/internal/rcon/rcon.go
@@ -1,36 +1,278 @@
+// Basic Rcon implementation according to https://minecraft.wiki/Rcon
 package rcon
 
 import (
-	"context"
+	"bufio"
+	"bytes"
+	"encoding/binary"
 	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unicode/utf8"
 
-	"github.com/jltobler/go-rcon"
+	"github.com/nickheyer/discopanel/pkg/logger"
+	"golang.org/x/text/encoding/charmap"
 )
 
-type rconResult struct {
-	output string
-	err    error
+const (
+	packetAuth          int32 = 3
+	packetAuthResponse  int32 = 2
+	packetExecCommand   int32 = 2
+	packetResponseValue int32 = 0
+
+	defaultTimeout = 3 * time.Second
+)
+
+type RconPacket struct {
+	Size int32
+	ID   int32
+	Type int32
+	Body string
 }
 
-func SendCommand(ctx context.Context, RCONHost string, RCONPort int, RCONPassword string, command string) (string, error) {
-	// initialize Client
-	rconClient := rcon.NewClient(fmt.Sprintf("rcon://%s:%d", RCONHost, RCONPort), RCONPassword)
+type Client struct {
+	host     string
+	port     int
+	password string
+	log      *logger.Logger
 
-	// run Command in a goroutine to allow for timeout handling
-	resultCh := make(chan rconResult, 1)
-	go func() {
-		output, sendErr := rconClient.Send(command)
-		resultCh <- rconResult{output: output, err: sendErr}
-	}()
+	packetID atomic.Int32
+	mu       sync.Mutex
+	conn     net.Conn
+	reader   *bufio.Reader
+}
 
-	// wait for either the command result or a timeout
-	select {
-	case <-ctx.Done():
-		return "", ctx.Err()
-	case result := <-resultCh:
-		if result.err != nil {
-			return "", result.err
-		}
-		return result.output, nil
+func NewClient(host string, port int, password string, log *logger.Logger) *Client {
+	return &Client{
+		host:     host,
+		port:     port,
+		password: password,
+		log:      log,
 	}
+}
+
+func (c *Client) Host() string     { return c.host }
+func (c *Client) Port() int        { return c.port }
+func (c *Client) Password() string { return c.password }
+
+func (c *Client) nextPacketID() int32 {
+	id := c.packetID.Add(1)
+
+	if id <= 0 {
+		c.packetID.Store(1)
+		return 1
+	}
+
+	return id
+}
+
+func (c *Client) Connect() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.connectLocked()
+}
+
+func (c *Client) connectLocked() error {
+	c.closeLocked()
+
+	addr := net.JoinHostPort(c.host, fmt.Sprintf("%d", c.port))
+	conn, err := net.DialTimeout("tcp", addr, defaultTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to connect to RCON server: %w", err)
+	}
+
+	reader := bufio.NewReader(conn)
+
+	// authenticate
+	if err := c.authenticate(conn, reader); err != nil {
+		conn.Close()
+		return err
+	}
+
+	c.conn = conn
+	c.reader = reader
+	c.log.Info("RCON connection established successfully")
+	return nil
+}
+
+func (c *Client) Execute(command string) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	res, err := c.executeLocked(command)
+	if err == nil {
+		return res, nil
+	}
+
+	c.log.Warn("RCON command failed, retrying connection... Error: %v", err)
+	if reconnected := c.connectLocked(); reconnected == nil {
+		return c.executeLocked(command)
+	}
+
+	return "", err
+}
+
+func (c *Client) executeLocked(command string) (string, error) {
+
+	if c.conn == nil {
+		if err := c.connectLocked(); err != nil {
+			return "", err
+		}
+	}
+
+	_ = c.conn.SetDeadline(time.Now().Add(defaultTimeout))
+
+	cmdPacket := RconPacket{
+		ID:   c.nextPacketID(),
+		Type: packetExecCommand,
+		Body: command,
+	}
+
+	err := writePacket(c.conn, cmdPacket, c.log)
+	if err != nil {
+		c.closeLocked()
+		return "", err
+	}
+
+	// dummy packet to detect end of output
+	terminator := RconPacket{
+		ID:   c.nextPacketID(),
+		Type: packetExecCommand,
+		Body: "",
+	}
+
+	err = writePacket(c.conn, terminator, c.log)
+	if err != nil {
+		c.closeLocked()
+		return "", err
+	}
+
+	var response strings.Builder
+
+	for {
+		resp, err := readPacket(c.reader, c.log)
+		if err != nil {
+			c.closeLocked()
+			return "", err
+		}
+
+		if resp.ID == cmdPacket.ID {
+			response.WriteString(resp.Body)
+		}
+
+		if resp.ID == terminator.ID {
+			break
+		}
+	}
+
+	return response.String(), nil
+}
+
+func (c *Client) authenticate(conn net.Conn, reader *bufio.Reader) error {
+	authPacket := RconPacket{
+		ID:   1,
+		Type: packetAuth,
+		Body: c.password,
+	}
+	err := writePacket(conn, authPacket, c.log)
+	if err != nil {
+		conn.Close()
+		return fmt.Errorf("failed to send auth packet: %w", err)
+	}
+
+	response, err := readPacket(reader, c.log)
+	if err != nil {
+		conn.Close()
+		return fmt.Errorf("failed to read auth response: %w", err)
+	}
+
+	if response.ID == -1 || response.Type != packetAuthResponse {
+		return fmt.Errorf("authentication failed: invalid response")
+	}
+	return nil
+}
+
+func (c *Client) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.closeLocked()
+}
+
+func (c *Client) closeLocked() error {
+	if c.conn != nil {
+		err := c.conn.Close()
+		c.conn = nil
+		c.reader = nil
+		return err
+	}
+	return nil
+}
+
+func writePacket(conn net.Conn, packet RconPacket, log *logger.Logger) error {
+	// log.Debug("Sending Packet: ID=%d, Type=%d, Body=%q\n", packet.ID, packet.Type, packet.Body)
+	bodyBytes := []byte(packet.Body)
+	size := 4 + 4 + len(bodyBytes) + 2
+
+	buf := make([]byte, 4+size)
+
+	binary.LittleEndian.PutUint32(buf[0:4], uint32(size))
+	binary.LittleEndian.PutUint32(buf[4:8], uint32(packet.ID))
+	binary.LittleEndian.PutUint32(buf[8:12], uint32(packet.Type))
+
+	copy(buf[12:], bodyBytes)
+
+	buf[len(buf)-2] = 0x00
+	buf[len(buf)-1] = 0x00
+
+	_, err := conn.Write(buf)
+
+	return err
+}
+
+func readPacket(reader *bufio.Reader, log *logger.Logger) (RconPacket, error) {
+	var packet RconPacket
+
+	sizeBytes := make([]byte, 4)
+	_, err := io.ReadFull(reader, sizeBytes)
+	if err != nil {
+		return packet, fmt.Errorf("failed to read packet size: %w", err)
+	}
+
+	size := binary.LittleEndian.Uint32(sizeBytes)
+	packetBytes := make([]byte, size)
+	_, err = io.ReadFull(reader, packetBytes)
+	if err != nil {
+		return packet, fmt.Errorf("failed to read packet data: %w", err)
+	}
+
+	packet.Size = int32(size)
+	packet.ID = int32(binary.LittleEndian.Uint32(packetBytes[0:4]))
+	packet.Type = int32(binary.LittleEndian.Uint32(packetBytes[4:8]))
+	packet.Body = decodeOutput(packetBytes[8 : len(packetBytes)-2])
+
+	// log.Debug("Received Packet: ID=%d, Type=%d, Body=%q\n", packet.ID, packet.Type, packet.Body)
+
+	return packet, nil
+}
+
+func decodeOutput(input []byte) string {
+	// just return if valid UTF-8
+	if utf8.Valid(input) {
+		return string(input)
+	}
+
+	// convert ISO-8859_1 to UTF-8 (old server versions)
+	decoded, err := charmap.ISO8859_1.NewDecoder().Bytes(input)
+	if err == nil {
+		return string(decoded)
+	}
+
+	// fallback
+	return string(bytes.ToValidUTF8(input, []byte("?")))
 }

--- a/internal/rpc/services/server.go
+++ b/internal/rpc/services/server.go
@@ -947,6 +947,9 @@ func (s *ServerService) UpdateServer(ctx context.Context, req *connect.Request[v
 			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get server configuration"))
 		}
 
+		// close rcon connection
+		s.sender.Remove(server.ID)
+
 		// Recreate container
 		result, err := s.docker.RecreateContainer(ctx, server.ContainerID, server, serverConfig)
 		if err != nil {
@@ -986,6 +989,9 @@ func (s *ServerService) DeleteServer(ctx context.Context, req *connect.Request[v
 	if err != nil {
 		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("server not found"))
 	}
+
+	// close rcon connection
+	s.sender.Remove(server.ID)
 
 	// Remove proxy route if configured
 	if s.proxy != nil && server.ProxyHostname != "" {
@@ -1042,6 +1048,9 @@ func (s *ServerService) StartServer(ctx context.Context, req *connect.Request[v1
 	if err != nil {
 		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("server not found"))
 	}
+
+	// close rcon connection
+	s.sender.Remove(server.ID)
 
 	// If container doesn't exist, create it first
 	if server.ContainerID == "" {
@@ -1145,6 +1154,9 @@ func (s *ServerService) StopServer(ctx context.Context, req *connect.Request[v1.
 		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("server not found"))
 	}
 
+	// close rcon connection
+	s.sender.Remove(server.ID)
+
 	if server.ContainerID == "" {
 		// If there's no container, server is already stopped
 		server.Status = storage.StatusStopped
@@ -1206,6 +1218,9 @@ func (s *ServerService) RestartServer(ctx context.Context, req *connect.Request[
 	if err != nil {
 		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("server not found"))
 	}
+
+	// close rcon connection
+	s.sender.Remove(server.ID)
 
 	// If container doesn't exist, create it and start it
 	if server.ContainerID == "" {
@@ -1307,6 +1322,9 @@ func (s *ServerService) RecreateServer(ctx context.Context, req *connect.Request
 		s.log.Error("Failed to get server config: %v", err)
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get server configuration"))
 	}
+
+	// close rcon connection
+	s.sender.Remove(server.ID)
 
 	// Recreate container
 	result, err := s.docker.RecreateContainer(ctx, server.ContainerID, server, serverConfig)

--- a/web/discopanel/src/lib/components/server-console.svelte
+++ b/web/discopanel/src/lib/components/server-console.svelte
@@ -33,12 +33,73 @@
 
 	// Create ansi-to-html converter with proper options
 	const ansiConverter = new AnsiToHtml({
-		fg: '#e8e8e8',
-		bg: '#000000',
-		newline: false,
-		escapeXML: true,
-		stream: true
+	    fg: '#e8e8e8',
+	    bg: '#000000',
+	    newline: false,
+	    escapeXML: true,
+	    stream: true,
+	    colors: {
+
+			// color codes according to https://minecraft.wiki/w/Formatting_codes#Color_codes
+
+	        "30": '#000000', // §0 - black
+	        "34": '#0000AA', // §1 - dark_blue
+	        "32": '#00AA00', // §2 - dark_green
+	        "36": '#00AAAA', // §3 - dark_aqua
+	        "31": '#AA0000', // §4 - dark_red
+	        "35": '#AA00AA', // §5 - dark_purple
+	        "33": '#FFAA00', // §6 - gold
+	        "37": '#AAAAAA', // §7 - gray
+
+
+	        "90": '#555555', // §8 - dark_gray
+	        "94": '#5555FF', // §9 - blue
+	        "92": '#55FF55', // §a - green
+	        "96": '#55FFFF', // §b - aqua
+	        "91": '#FF5555', // §c - red
+	        "95": '#FF55FF', // §d - light_purple
+	        "93": '#FFFF55', // §e - yellow
+	        "97": '#FFFFFF'  // §f - white
+	    }
 	});
+
+	function parseMinecraftColors(text: string): string {
+	    const codes: Record<string, string> = {
+			// color codes according to https://minecraft.wiki/w/Formatting_codes#Color_codes
+
+	        '0': '\x1b[0;30m', 
+			'1': '\x1b[0;34m', 
+			'2': '\x1b[0;32m', 
+			'3': '\x1b[0;36m', 
+			'4': '\x1b[0;31m', 
+			'5': '\x1b[0;35m', 
+			'6': '\x1b[0;33m', 
+			'7': '\x1b[0;37m',
+
+	        '8': '\x1b[0;90m', 
+			'9': '\x1b[0;94m', 
+			'a': '\x1b[0;92m', 
+			'b': '\x1b[0;96m', 
+			'c': '\x1b[0;91m', 
+			'd': '\x1b[0;95m', 
+			'e': '\x1b[0;93m', 
+			'f': '\x1b[0;97m',
+		
+			
+	        // formatting codes according to https://minecraft.wiki/w/Formatting_codes#Formatting_codes
+	        'l': '\x1b[1m',  // bold (\x1b[1m)
+	        'm': '\x1b[9m',  // strikethrough (\x1b[9m)
+	        'n': '\x1b[4m',  // underlined (\x1b[4m)
+	        'o': '\x1b[3m',  // italic (\x1b[3m)
+	        'r': '\x1b[0m'   // reset (\x1b[0m)
+	    };
+
+		// replace minecraft color code with ansi escape sequences 
+	    return text.replace(/§([0-9a-frlmno])/g, (_, code) => {
+	        return codes[code];
+	    }).concat('\x1b[0m'); // reset at the end to prevent bleed
+	}
+
 
 	let { server, active = false }: { server: Server; active?: boolean } = $props();
 
@@ -396,7 +457,7 @@
 						{#each logEntries as entry, i (i)}
 							<div class="log-line break-all whitespace-pre-wrap" data-type={entry.level}>
 								<!-- eslint-disable-next-line svelte/no-at-html-tags -->
-								{@html ansiConverter.toHtml(entry.message)}
+								{@html ansiConverter.toHtml(parseMinecraftColors(entry.message))}
 							</div>
 						{/each}
 					{/if}


### PR DESCRIPTION
### Summary
This PR replaces the existing, unmaintained RCON library with a clean, ground-up implementation built strictly around the [Minecraft RCON Protocol specification](https://minecraft.wiki/Rcon).

### Problem
The default Minecraft RCON protocol does not provide an explicit mechanism or end-of-stream indicator to signal when a multi-packet response has finished sending:

"There's no simple way to know when the last response packet has been received."

Common workarounds have notable trade-offs:
**_Checking for payload length < 4096:_** Unreliable if the final payload chunk happens to align with the 4096-byte boundary.
**_Fixed Timeouts (Wait **N** seconds):_** Introduces unnecessary latency for short responses and remains brittle under server lag.
**_Terminator / Dummy Packet:_** Leverages the fact that Minecraft server processes RCON commands synchronously on the main thread. 

### Implementation Details
We adopted Option 3 (Terminator Packet) for reliable response framing:
_**Send Command Packet:**_ Transmit the target command packet to the server. 
**_Send Dummy/Terminator Packet:_** Immediately follow with an empty payload command packet (using a distinct request ID).
**Read & Assemble:** Read incoming packets sequentially, appending payload data until a response matching the dummy packet's request ID is received.
_**Socket Timeout:**_ Included a standard socket read timeout (3s) to prevent hanging if the connection unexpectedly drops before receiving the terminator.

Additionally, character encoding handling was updated to support fallback encodings for older Minecraft server versions that do not output standard UTF-8.

### Known Limitations
_**Asynchronous Commands:**_ Commands executed asynchronously by third-party plugins (e.g., `/spark` profiling commands or Bukkit's `/version`) do not send output back through the synchronous RCON thread.

Note: Testing confirmed that even with long timeout windows (up to 10s without a dummy packet), these commands return no output payload over RCON. (reference: [spark issue #119](https://github.com/lucko/spark/issues/119)).

### Addition Stuff
Update Frontend Console to correctly display minecraft Formatting Codes.