### PR TITLE
[Fix] TPS Extraction through Modes

### DIFF
--- a/cmd/status/templates/index.tmpl
+++ b/cmd/status/templates/index.tmpl
@@ -288,6 +288,7 @@
             <div class="p-4">
                 <div class="grid grid-cols-2 gap-3">
                     <!-- TPS -->
+                    {{if .Server.TPSEnabled}}
                     <div class="group bg-muted/50 hover:bg-muted border border-border hover:border-white/10 rounded-xl p-3.5 transition-all duration-200">
                         <div class="flex items-center justify-between mb-2">
                             <span class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/70">TPS</span>
@@ -301,6 +302,7 @@
                             </div>
                         </div>
                     </div>
+                    {{end}}
 
                     <!-- CPU -->
                     <div class="group bg-muted/50 hover:bg-muted border border-border hover:border-white/10 rounded-xl p-3.5 transition-all duration-200">

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -69,31 +69,44 @@ const (
 	ModLoaderModrinth       ModLoader = "modrinth"
 )
 
+type TPSExtractionMode string
+
+const (
+	TPSExtractionModeVanilla TPSExtractionMode = "vanilla"
+	TPSExtractionModeForge   TPSExtractionMode = "forge"
+	TPSExtractionModeSpigot  TPSExtractionMode = "spigot"
+	TPSExtractionModeCustom  TPSExtractionMode = "custom"
+	TPSExtractionModeLegacy  TPSExtractionMode = "legacy"
+)
+
 type Server struct {
-	ID              string               `json:"id" gorm:"primaryKey"`
-	Name            string               `json:"name" gorm:"not null"`
-	Description     string               `json:"description"`
-	ModLoader       ModLoader            `json:"mod_loader" gorm:"not null"`
-	MCVersion       string               `json:"mc_version" gorm:"not null;column:mc_version"`
-	ContainerID     string               `json:"container_id" gorm:"column:container_id"`
-	Status          ServerStatus         `json:"status" gorm:"not null"`
-	Port            int                  `json:"port"`
-	ProxyPort       int                  `json:"proxy_port" gorm:"column:proxy_port"`
-	ProxyHostname   string               `json:"proxy_hostname" gorm:"column:proxy_hostname;uniqueIndex:idx_proxy_hostname_listener,where:proxy_hostname != ''"`
-	ProxyListenerID string               `json:"proxy_listener_id" gorm:"column:proxy_listener_id;uniqueIndex:idx_proxy_hostname_listener,where:proxy_listener_id != ''"` // Which listener this server uses
-	MaxPlayers      int                  `json:"max_players" gorm:"default:20;column:max_players"`
-	Memory          int                  `json:"memory" gorm:"default:4096"` // in MB (allocated) - IMPORTANT: This applies to the container's memory allocation first, then used to calc the JVM min/max for mc server proc inside w/ overhead
-	CreatedAt       time.Time            `json:"created_at" gorm:"autoCreateTime"`
-	UpdatedAt       time.Time            `json:"updated_at" gorm:"autoUpdateTime"`
-	LastStarted     *time.Time           `json:"last_started" gorm:"column:last_started"`
-	JavaVersion     string               `json:"java_version" gorm:"column:java_version"`
-	DockerImage     string               `json:"docker_image" gorm:"column:docker_image"`
-	DataPath        string               `json:"data_path" gorm:"not null;column:data_path"`
-	Detached        bool                 `json:"detached" gorm:"default:false;column:detached"`                             // Detach server container from DiscoPanel lifecycle (default: false)
-	AutoStart       bool                 `json:"auto_start" gorm:"default:false;column:auto_start"`                         // Start server when DiscoPanel starts (default: false)
-	TPSCommand      string               `json:"tps_command" gorm:"column:tps_command"`                                     // The TPS command for this server (empty if not supported)
-	AdditionalPorts []*v1.AdditionalPort `json:"additional_ports" gorm:"column:additional_ports;serializer:json"`           // Additional port configurations
-	DockerOverrides *v1.DockerOverrides  `json:"docker_overrides" gorm:"column:docker_overrides;type:text;serializer:json"` // Docker container overrides
+	ID                string               `json:"id" gorm:"primaryKey"`
+	Name              string               `json:"name" gorm:"not null"`
+	Description       string               `json:"description"`
+	ModLoader         ModLoader            `json:"mod_loader" gorm:"not null"`
+	MCVersion         string               `json:"mc_version" gorm:"not null;column:mc_version"`
+	ContainerID       string               `json:"container_id" gorm:"column:container_id"`
+	Status            ServerStatus         `json:"status" gorm:"not null"`
+	Port              int                  `json:"port"`
+	ProxyPort         int                  `json:"proxy_port" gorm:"column:proxy_port"`
+	ProxyHostname     string               `json:"proxy_hostname" gorm:"column:proxy_hostname;uniqueIndex:idx_proxy_hostname_listener,where:proxy_hostname != ''"`
+	ProxyListenerID   string               `json:"proxy_listener_id" gorm:"column:proxy_listener_id;uniqueIndex:idx_proxy_hostname_listener,where:proxy_listener_id != ''"` // Which listener this server uses
+	MaxPlayers        int                  `json:"max_players" gorm:"default:20;column:max_players"`
+	Memory            int                  `json:"memory" gorm:"default:4096"` // in MB (allocated) - IMPORTANT: This applies to the container's memory allocation first, then used to calc the JVM min/max for mc server proc inside w/ overhead
+	CreatedAt         time.Time            `json:"created_at" gorm:"autoCreateTime"`
+	UpdatedAt         time.Time            `json:"updated_at" gorm:"autoUpdateTime"`
+	LastStarted       *time.Time           `json:"last_started" gorm:"column:last_started"`
+	JavaVersion       string               `json:"java_version" gorm:"column:java_version"`
+	DockerImage       string               `json:"docker_image" gorm:"column:docker_image"`
+	DataPath          string               `json:"data_path" gorm:"not null;column:data_path"`
+	Detached          bool                 `json:"detached" gorm:"default:false;column:detached"`     // Detach server container from DiscoPanel lifecycle (default: false)
+	AutoStart         bool                 `json:"auto_start" gorm:"default:false;column:auto_start"` // Start server when DiscoPanel starts (default: false)
+	TPSEnabled        bool                 `json:"tps_enabled" gorm:"default:true;column:tps_enabled"`
+	TPSCommand        string               `json:"tps_command" gorm:"column:tps_command"` // The TPS command for this server (empty if not supported)
+	TPSExtractionMode TPSExtractionMode    `json:"tps_extraction_mode" gorm:"column:tps_extraction_mode;default:'legacy';not null"`
+	TPSCustomRegex    string               `json:"tps_custom_regex" gorm:"column:tps_custom_regex"`
+	AdditionalPorts   []*v1.AdditionalPort `json:"additional_ports" gorm:"column:additional_ports;serializer:json"`           // Additional port configurations
+	DockerOverrides   *v1.DockerOverrides  `json:"docker_overrides" gorm:"column:docker_overrides;type:text;serializer:json"` // Docker container overrides
 
 	// Runtime stats (not persisted to DB)
 	MemoryUsage   float64 `json:"memory_usage" gorm:"-"`   // Current memory usage in MB

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -313,23 +313,64 @@ func (c *Collector) collectRCONData() {
 		}
 
 		// Get TPS if configured
-		if server.TPSCommand != "" {
-			for _, cmd := range strings.Split(server.TPSCommand, " ?? ") {
-				cmd = strings.TrimSpace(cmd)
-				if cmd == "" {
-					continue
-				}
-				output, err := c.sender.SendCommand(ctx, server.ID, cmd)
-				if err == nil && output != "" {
-					tps := minecraft.ParseTPSFromOutput(output)
-					if tps > 0 {
-						c.updateMetrics(server.ID, func(m *ServerMetrics) {
-							m.TPS = tps
-							m.LastUpdated = time.Now()
-						})
-						break
-					}
-				}
+		if server.TPSEnabled && server.TPSCommand != "" {
+			if server.TPSExtractionMode == storage.TPSExtractionModeLegacy {
+				c.legacyTpsExtraction(ctx, server)
+			} else {
+				c.tpsExtraction(ctx, server)
+			}
+
+		}
+	}
+}
+
+func (c *Collector) tpsExtraction(ctx context.Context, server *storage.Server) {
+	command, _, _ := strings.Cut(server.TPSCommand, " ?? ")
+	if command == "" {
+		return
+	}
+
+	output, err := c.sender.SendCommand(ctx, server.ID, command)
+	if err != nil {
+		return
+	}
+
+	var tps float64
+	switch server.TPSExtractionMode {
+	case storage.TPSExtractionModeVanilla:
+		tps = minecraft.ParseTPSVanilla(output)
+	case storage.TPSExtractionModeForge:
+		tps = minecraft.ParseTPSForge(output)
+	case storage.TPSExtractionModeSpigot:
+		tps = minecraft.ParseTPSSpigot(output)
+	case storage.TPSExtractionModeCustom:
+		tps = minecraft.ParseTPSCustom(output, server.TPSCustomRegex)
+	}
+
+	if tps > 0 {
+		c.updateMetrics(server.ID, func(m *ServerMetrics) {
+			m.TPS = tps
+			m.LastUpdated = time.Now()
+		})
+	}
+
+}
+
+func (c *Collector) legacyTpsExtraction(ctx context.Context, server *storage.Server) {
+	for cmd := range strings.SplitSeq(server.TPSCommand, " ?? ") {
+		cmd = strings.TrimSpace(cmd)
+		if cmd == "" {
+			continue
+		}
+		output, err := c.sender.SendCommand(ctx, server.ID, cmd)
+		if err == nil && output != "" {
+			tps := minecraft.ParseTPSFromOutput(output)
+			if tps > 0 {
+				c.updateMetrics(server.ID, func(m *ServerMetrics) {
+					m.TPS = tps
+					m.LastUpdated = time.Now()
+				})
+				break
 			}
 		}
 	}

--- a/internal/minecraft/utils.go
+++ b/internal/minecraft/utils.go
@@ -1,11 +1,23 @@
 package minecraft
 
 import (
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
 
 	models "github.com/nickheyer/discopanel/internal/db"
+)
+
+var (
+	// RegEx for Average time per tick (f. e. "Average time per tick: 0.2ms")
+	reVanillaTarget = regexp.MustCompile(`Target tick rate:\s*(\d+(?:\.\d+)?)`)
+
+	// RegEx for Average time per tick (f. e. "Average time per tick: 0.2ms")
+	reVanillaAvg     = regexp.MustCompile(`Average time per tick:\s*(\d+(?:\.\d+)?)ms`)
+	reForgeOverall   = regexp.MustCompile(`Overall:.*Mean TPS:\s*(\d+(?:\.\d+)?)`)
+	reForgeOverworld = regexp.MustCompile(`Dim minecraft:overworld.*Mean TPS:\s*(\d+(?:\.\d+)?)`)
+	reSpigot         = regexp.MustCompile(`TPS from last 1m, 5m, 15m:\s*[*~>]?\s*(\d+(?:\.\d+)?)`)
 )
 
 // ParseTPSFromOutput parses TPS value from various server command outputs
@@ -100,6 +112,78 @@ func ParseTPSFromOutput(output string) float64 {
 	return 0
 }
 
+// example output:
+// The game is running normallyTarget tick rate: 20.0 per second.
+// Average time per tick: 0.2ms (Target: 50.0ms)Percentiles: P50: 0.2ms P95: 0.4ms P99: 2.3ms. Sample: 100
+func ParseTPSVanilla(output string) float64 {
+	output = stripMinecraftColors(output)
+
+	matchTarget := reVanillaTarget.FindStringSubmatch(output)
+	matchAvg := reVanillaAvg.FindStringSubmatch(output)
+
+	// value not found
+	if len(matchTarget) < 2 || len(matchAvg) < 2 {
+		return 0.0
+	}
+
+	targetTPS, err1 := strconv.ParseFloat(matchTarget[1], 64)
+	avgTickTimeMS, err2 := strconv.ParseFloat(matchAvg[1], 64)
+
+	if err1 != nil || err2 != nil || avgTickTimeMS <= 0 {
+		return 0.0
+	}
+
+	// mathematically possible TPS
+	calculatedTPS := 1000.0 / avgTickTimeMS
+
+	// TPS can't be bigger than targetTPS
+	currentTPS := math.Min(targetTPS, calculatedTPS)
+
+	return currentTPS
+}
+
+// example output:
+// Dim minecraft:overworld (minecraft:overworld): Mean tick time: 0.255 ms. Mean TPS: 20.000
+// Dim minecraft:the_nether (minecraft:the_nether): Mean tick time: 0.065 ms. Mean TPS: 20.000
+// Dim minecraft:the_end (minecraft:the_end): Mean tick time: 0.051 ms. Mean TPS: 20.000
+// Overall: Mean tick time: 0.477 ms. Mean TPS: 20.000
+func ParseTPSForge(output string) float64 {
+
+	var tps float64
+	// Priority Overall
+	tps = ParseTPSRegex(output, reForgeOverall)
+
+	if tps > 0.0 {
+		return tps
+	}
+	// fallback overworld
+	return ParseTPSRegex(output, reForgeOverworld)
+}
+
+// example output:
+// TPS from last 1m, 5m, 15m: *20.0, *20.0, *20.0
+// Current Memory Usage: 238/922 mb (Max: 1536 mb)
+func ParseTPSSpigot(output string) float64 {
+	return ParseTPSRegex(output, reSpigot)
+}
+
+func ParseTPSCustom(output string, regex string) float64 {
+	output = stripMinecraftColors(output)
+	return ParseTPSRegex(output, regexp.MustCompile(regex))
+}
+
+func ParseTPSRegex(output string, regex *regexp.Regexp) float64 {
+	output = stripMinecraftColors(output)
+	match := regex.FindStringSubmatch(output)
+	if len(match) >= 2 {
+		if tps, err := strconv.ParseFloat(match[1], 64); err == nil {
+			return tps
+		}
+	}
+
+	return 0.0
+}
+
 // ParsePlayerListFromOutput parses player count and names from list command output
 func ParsePlayerListFromOutput(output string) (int, []string) {
 	output = stripMinecraftColors(output)
@@ -176,4 +260,127 @@ func GetTPSCommand(modLoader models.ModLoader) string {
 	default:
 		return "forge tps ?? neoforge tps ?? tps"
 	}
+}
+
+func GetTPSInfo(modLoader models.ModLoader, version string) (string, models.TPSExtractionMode) {
+	// Determine TPS command based on modloader
+	switch modLoader {
+	case models.ModLoaderPaper, models.ModLoaderFolia, models.ModLoaderPurpur, models.ModLoaderSpigot, models.ModLoaderBukkit, models.ModLoaderPufferfish:
+		return "tps", models.TPSExtractionModeSpigot
+	case models.ModLoaderForge:
+		return "forge tps", models.TPSExtractionModeForge
+	case models.ModLoaderNeoForge:
+		return "neoforge tps", models.TPSExtractionModeForge
+	// Fabric-based need Carpet mod for TPS
+	// Hybrids might support TPS if they have Bukkit API
+	case models.ModLoaderMagma, models.ModLoaderMagmaMaintained, models.ModLoaderMohist, models.ModLoaderArclight:
+		return "tps", models.TPSExtractionModeSpigot
+	// Vanilla and others don't have TPS command
+	case models.ModLoaderVanilla:
+		if CompareMinecraftVersion(version, "1.20.3") >= 1 {
+			return "tick query", models.TPSExtractionModeVanilla
+		}
+		return "", models.TPSExtractionModeLegacy
+
+	default:
+		return "", models.TPSExtractionModeLegacy
+	}
+}
+
+// Priority-weighting Higher = Newer
+var tagPriority = map[string]int{
+	"snapshot": 1,
+	"pre":      2,
+	"rc":       3,
+	"":         4, // regular release
+}
+
+type ParsedVersion struct {
+	Base  []int  // f.e. [26, 2]
+	Tag   string // f.e. "rc", "pre", "snapshot", or ""
+	Build int    // f.e. 2 at "rc-2"
+}
+
+func parseVersion(v string) ParsedVersion {
+	// delete "(Latest)"
+	v = strings.TrimSpace(strings.Split(v, "(")[0])
+
+	pv := ParsedVersion{}
+
+	// check for tag (f.e. -rc-2)
+	parts := strings.SplitN(v, "-", 2)
+
+	// parse base version ("26.2" -> [26, 2])
+	baseStrParts := strings.Split(parts[0], ".")
+	for _, p := range baseStrParts {
+		num, _ := strconv.Atoi(p)
+		pv.Base = append(pv.Base, num)
+	}
+
+	// if tag exists ("rc-2" or "snapshot-1")
+	if len(parts) > 1 {
+		tagParts := strings.Split(parts[1], "-")
+		pv.Tag = tagParts[0] // f.e. "rc"
+
+		if len(tagParts) > 1 {
+			pv.Build, _ = strconv.Atoi(tagParts[1]) // f.e. 2
+		}
+	}
+
+	return pv
+}
+
+// CompareMinecraftVersion compares two minecraft versions.
+// Returns:
+//
+//	-1 : v1 < v2
+//	 0 : v1 == v2
+//	 1 : v1 > v2
+func CompareMinecraftVersion(v1, v2 string) int {
+	pv1 := parseVersion(v1)
+	pv2 := parseVersion(v2)
+
+	// 1. Compare Base Version (f.e. 26.3 vs 26.2)
+	maxLen := len(pv1.Base)
+	if len(pv2.Base) > maxLen {
+		maxLen = len(pv2.Base)
+	}
+
+	for i := 0; i < maxLen; i++ {
+		var n1, n2 int
+		if i < len(pv1.Base) {
+			n1 = pv1.Base[i]
+		}
+		if i < len(pv2.Base) {
+			n2 = pv2.Base[i]
+		}
+
+		if n1 < n2 {
+			return -1
+		}
+		if n1 > n2 {
+			return 1
+		}
+	}
+
+	// 2. Pre-Release Tag-Hierarchy Comparison (Release > rc > pre > snapshot)
+	prio1 := tagPriority[pv1.Tag]
+	prio2 := tagPriority[pv2.Tag]
+
+	if prio1 < prio2 {
+		return -1
+	}
+	if prio1 > prio2 {
+		return 1
+	}
+
+	// 3. if tag is identical (f.e. rc-1 vs rc-2), compare Build-Number
+	if pv1.Build < pv2.Build {
+		return -1
+	}
+	if pv1.Build > pv2.Build {
+		return 1
+	}
+
+	return 0
 }

--- a/internal/rpc/services/minecraft.go
+++ b/internal/rpc/services/minecraft.go
@@ -139,3 +139,12 @@ func (s *MinecraftService) GetDockerImages(ctx context.Context, req *connect.Req
 		Images: protoImages,
 	}), nil
 }
+
+func (s *MinecraftService) GetTestTPSRegex(ctx context.Context, req *connect.Request[v1.GetTestTPSRegexRequest]) (*connect.Response[v1.GetTestTPSRegexResponse], error) {
+	msg := req.Msg
+	tps := minecraft.ParseTPSCustom(msg.Input, msg.Regex)
+
+	return connect.NewResponse(&v1.GetTestTPSRegexResponse{
+		Tps: tps,
+	}), nil
+}

--- a/internal/rpc/services/server.go
+++ b/internal/rpc/services/server.go
@@ -75,33 +75,36 @@ func dbServerToProto(server *storage.Server) *v1.Server {
 	javaVersion, _ := strconv.ParseInt(server.JavaVersion, 10, 32)
 
 	protoServer := &v1.Server{
-		Id:              server.ID,
-		Name:            server.Name,
-		Description:     server.Description,
-		McVersion:       server.MCVersion,
-		Port:            int32(server.Port),
-		ProxyHostname:   server.ProxyHostname,
-		ProxyListenerId: server.ProxyListenerID,
-		ProxyPort:       int32(server.ProxyPort),
-		MaxPlayers:      int32(server.MaxPlayers),
-		Memory:          int32(server.Memory),
-		DataPath:        server.DataPath,
-		ContainerId:     server.ContainerID,
-		JavaVersion:     int32(javaVersion),
-		DockerImage:     server.DockerImage,
-		AutoStart:       server.AutoStart,
-		Detached:        server.Detached,
-		TpsCommand:      server.TPSCommand,
-		MemoryUsage:     int64(server.MemoryUsage),
-		CpuPercent:      server.CPUPercent,
-		DiskUsage:       server.DiskUsage,
-		DiskTotal:       server.DiskTotal,
-		WorldSize:       server.WorldSize,
-		PlayersOnline:   int32(server.PlayersOnline),
-		Tps:             server.TPS,
-		AdditionalPorts: server.AdditionalPorts,
-		CreatedAt:       timestamppb.New(server.CreatedAt),
-		UpdatedAt:       timestamppb.New(server.UpdatedAt),
+		Id:                server.ID,
+		Name:              server.Name,
+		Description:       server.Description,
+		McVersion:         server.MCVersion,
+		Port:              int32(server.Port),
+		ProxyHostname:     server.ProxyHostname,
+		ProxyListenerId:   server.ProxyListenerID,
+		ProxyPort:         int32(server.ProxyPort),
+		MaxPlayers:        int32(server.MaxPlayers),
+		Memory:            int32(server.Memory),
+		DataPath:          server.DataPath,
+		ContainerId:       server.ContainerID,
+		JavaVersion:       int32(javaVersion),
+		DockerImage:       server.DockerImage,
+		AutoStart:         server.AutoStart,
+		Detached:          server.Detached,
+		TpsEnabled:        server.TPSEnabled,
+		TpsCommand:        server.TPSCommand,
+		TpsExtractionMode: dbTPSExtractionModeToProto(server.TPSExtractionMode),
+		TpsCustomRegex:    &server.TPSCustomRegex,
+		MemoryUsage:       int64(server.MemoryUsage),
+		CpuPercent:        server.CPUPercent,
+		DiskUsage:         server.DiskUsage,
+		DiskTotal:         server.DiskTotal,
+		WorldSize:         server.WorldSize,
+		PlayersOnline:     int32(server.PlayersOnline),
+		Tps:               server.TPS,
+		AdditionalPorts:   server.AdditionalPorts,
+		CreatedAt:         timestamppb.New(server.CreatedAt),
+		UpdatedAt:         timestamppb.New(server.UpdatedAt),
 
 		// SLP fields
 		SlpAvailable:    server.SLPAvailable,
@@ -168,6 +171,42 @@ func dbModLoaderToProto(loader storage.ModLoader) v1.ModLoader {
 		return v1.ModLoader_MOD_LOADER_NEOFORGE
 	default:
 		return v1.ModLoader_MOD_LOADER_VANILLA
+	}
+}
+
+func dbTPSExtractionModeToProto(TPSExtractionMode storage.TPSExtractionMode) v1.TPSExtractionMode {
+	switch TPSExtractionMode {
+	case storage.TPSExtractionModeCustom:
+		return v1.TPSExtractionMode_TPSExtractionModeCustom
+	case storage.TPSExtractionModeVanilla:
+		return v1.TPSExtractionMode_TPSExtractionModeVanilla
+	case storage.TPSExtractionModeForge:
+		return v1.TPSExtractionMode_TPSExtractionModeForge
+	case storage.TPSExtractionModeSpigot:
+		return v1.TPSExtractionMode_TPSExtractionModeSpigot
+	case storage.TPSExtractionModeLegacy:
+		return v1.TPSExtractionMode_TPSExtractionModeLegacy
+	default:
+		fmt.Printf("could not map db to proto value, got: %q\n", TPSExtractionMode)
+		return v1.TPSExtractionMode_TPSExtractionModeLegacy
+	}
+}
+
+func protoTPSExtractionModeToDB(TPSExtractionMode v1.TPSExtractionMode) storage.TPSExtractionMode {
+	switch TPSExtractionMode {
+	case v1.TPSExtractionMode_TPSExtractionModeCustom:
+		return storage.TPSExtractionModeCustom
+	case v1.TPSExtractionMode_TPSExtractionModeVanilla:
+		return storage.TPSExtractionModeVanilla
+	case v1.TPSExtractionMode_TPSExtractionModeForge:
+		return storage.TPSExtractionModeForge
+	case v1.TPSExtractionMode_TPSExtractionModeSpigot:
+		return storage.TPSExtractionModeSpigot
+	case v1.TPSExtractionMode_TPSExtractionModeLegacy:
+		return storage.TPSExtractionModeLegacy
+	default:
+		fmt.Printf("could not map proto to db value, got: %q\n", TPSExtractionMode)
+		return storage.TPSExtractionModeLegacy
 	}
 }
 
@@ -531,26 +570,31 @@ func (s *ServerService) CreateServer(ctx context.Context, req *connect.Request[v
 	serverDataDir := fmt.Sprintf("%s_%s", files.SanitizePathName(msg.Name), serverUUID)
 	serverDataPath := filepath.Join(s.config.Storage.DataDir, "servers", serverDataDir)
 
+	TPSCommand, TPSExtractionMode := minecraft.GetTPSInfo(modLoader, msg.McVersion)
+
 	server := &storage.Server{
-		ID:              serverUUID,
-		Name:            msg.Name,
-		Description:     msg.Description,
-		ModLoader:       modLoader,
-		MCVersion:       msg.McVersion,
-		Status:          storage.StatusCreating,
-		Port:            port,
-		ProxyHostname:   proxyHostname,
-		ProxyListenerID: proxyListenerID,
-		MaxPlayers:      int(msg.MaxPlayers),
-		Memory:          int(msg.Memory),
-		DataPath:        serverDataPath,
-		JavaVersion:     docker.GetRequiredJavaVersion(msg.McVersion, modLoader),
-		DockerImage:     dockerImage,
-		AutoStart:       msg.AutoStart,
-		Detached:        msg.Detached,
-		TPSCommand:      minecraft.GetTPSCommand(modLoader),
-		AdditionalPorts: additionalPorts,
-		DockerOverrides: msg.DockerOverrides,
+		ID:                serverUUID,
+		Name:              msg.Name,
+		Description:       msg.Description,
+		ModLoader:         modLoader,
+		MCVersion:         msg.McVersion,
+		Status:            storage.StatusCreating,
+		Port:              port,
+		ProxyHostname:     proxyHostname,
+		ProxyListenerID:   proxyListenerID,
+		MaxPlayers:        int(msg.MaxPlayers),
+		Memory:            int(msg.Memory),
+		DataPath:          serverDataPath,
+		JavaVersion:       docker.GetRequiredJavaVersion(msg.McVersion, modLoader),
+		DockerImage:       dockerImage,
+		AutoStart:         msg.AutoStart,
+		Detached:          msg.Detached,
+		TPSEnabled:        true,
+		TPSCommand:        TPSCommand,
+		TPSExtractionMode: TPSExtractionMode,
+		TPSCustomRegex:    "",
+		AdditionalPorts:   additionalPorts,
+		DockerOverrides:   msg.DockerOverrides,
 	}
 
 	// Set defaults
@@ -750,6 +794,7 @@ func (s *ServerService) UpdateServer(ctx context.Context, req *connect.Request[v
 	originalModLoader := server.ModLoader
 	originalMCVersion := server.MCVersion
 	originalDockerImage := server.DockerImage
+	originalTPSExtractionMode := server.TPSExtractionMode
 
 	// Update fields
 	if msg.Name != "" {
@@ -796,15 +841,18 @@ func (s *ServerService) UpdateServer(ctx context.Context, req *connect.Request[v
 			s.log.Error("Failed to update server config memory: %v", err)
 		}
 	}
-	if msg.ModLoader != "" && storage.ModLoader(msg.ModLoader) != originalModLoader {
-		server.ModLoader = storage.ModLoader(msg.ModLoader)
-		server.TPSCommand = minecraft.GetTPSCommand(server.ModLoader)
-		needsRecreation = true
-	}
+
 	if msg.McVersion != "" && msg.McVersion != originalMCVersion {
 		server.MCVersion = msg.McVersion
 		needsRecreation = true
 	}
+
+	if msg.ModLoader != "" && storage.ModLoader(msg.ModLoader) != originalModLoader {
+		server.ModLoader = storage.ModLoader(msg.ModLoader)
+		server.TPSCommand, server.TPSExtractionMode = minecraft.GetTPSInfo(server.ModLoader, server.MCVersion)
+		needsRecreation = true
+	}
+
 	if msg.DockerImage != "" && msg.DockerImage != originalDockerImage {
 		server.DockerImage = msg.DockerImage
 		needsRecreation = true
@@ -817,6 +865,17 @@ func (s *ServerService) UpdateServer(ctx context.Context, req *connect.Request[v
 	}
 	if msg.TpsCommand != nil {
 		server.TPSCommand = *msg.TpsCommand
+	}
+
+	if protoTPSExtractionModeToDB(msg.TpsExtractionMode) != originalTPSExtractionMode {
+		newExtractionMode := protoTPSExtractionModeToDB(msg.TpsExtractionMode)
+		if newExtractionMode == storage.TPSExtractionModeCustom {
+			if msg.TpsCustomRegex == nil || *msg.TpsCustomRegex == "" {
+				return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("Extraction mode custom needs regex"))
+			}
+			server.TPSCustomRegex = *msg.TpsCustomRegex
+		}
+		server.TPSExtractionMode = newExtractionMode
 	}
 
 	// Handle additional ports update

--- a/proto/discopanel/v1/common.proto
+++ b/proto/discopanel/v1/common.proto
@@ -41,6 +41,14 @@ enum ModLoader {
   MOD_LOADER_FOLIA = 17;
 }
 
+enum TPSExtractionMode {
+  TPSExtractionModeVanilla = 0;
+	TPSExtractionModeForge = 1;
+	TPSExtractionModeSpigot = 2;
+	TPSExtractionModeCustom = 3;
+	TPSExtractionModeLegacy = 4;
+}
+
 // System user account
 message User {
   string id = 1;
@@ -76,6 +84,9 @@ message Server {
   bool auto_start = 18;
   bool detached = 19;
   string tps_command = 20;
+  bool tps_enabled = 40;
+  TPSExtractionMode tps_extraction_mode = 41;
+  optional string tps_custom_regex = 42;
 
   // Runtime stats
   int64 memory_usage = 21;

--- a/proto/discopanel/v1/minecraft.proto
+++ b/proto/discopanel/v1/minecraft.proto
@@ -12,6 +12,8 @@ service MinecraftService {
   rpc GetModLoaders(GetModLoadersRequest) returns (GetModLoadersResponse);
   // List available Docker images
   rpc GetDockerImages(GetDockerImagesRequest) returns (GetDockerImagesResponse);
+  // Test Custom TPS Regex
+  rpc GetTestTPSRegex(GetTestTPSRegexRequest) returns (GetTestTPSRegexResponse);
 }
 
 // Minecraft version metadata
@@ -119,4 +121,13 @@ message SLPPlayers {
 message SLPPlayerSample {
   string name = 1;
   string id = 2; // UUID
+}
+
+message GetTestTPSRegexRequest {
+  string input = 1;
+  string regex = 2;
+}
+
+message GetTestTPSRegexResponse {
+  double tps = 1;
 }

--- a/proto/discopanel/v1/server.proto
+++ b/proto/discopanel/v1/server.proto
@@ -145,6 +145,9 @@ message UpdateServerRequest {
   optional bool auto_start = 10;
   optional bool detached = 11;
   optional string tps_command = 12;
+  bool tps_enabled = 17;
+  TPSExtractionMode tps_extraction_mode = 18;
+  optional string tps_custom_regex = 19;
   string modpack_id = 13;
   string modpack_version_id = 14;
   repeated AdditionalPort additional_ports = 15;

--- a/web/discopanel/src/lib/components/server-settings.svelte
+++ b/web/discopanel/src/lib/components/server-settings.svelte
@@ -8,12 +8,12 @@
 	import { rpcClient } from '$lib/api/rpc-client';
 	import { create } from '@bufbuild/protobuf';
 	import { toast } from 'svelte-sonner';
-	import { Loader2, Save, AlertCircle } from '@lucide/svelte';
+	import { Loader2, Save, AlertCircle, WandSparkles } from '@lucide/svelte';
 	import type { Server } from '$lib/proto/discopanel/v1/common_pb';
 	import * as _ from 'lodash-es';
-	import { ServerStatus, ModLoader } from '$lib/proto/discopanel/v1/common_pb';
+	import { ServerStatus, ModLoader, TPSExtractionMode } from '$lib/proto/discopanel/v1/common_pb';
 	import type { UpdateServerRequest } from '$lib/proto/discopanel/v1/server_pb';
-	import { UpdateServerRequestSchema } from '$lib/proto/discopanel/v1/server_pb';
+	import { SendCommandRequestSchema, UpdateServerRequestSchema } from '$lib/proto/discopanel/v1/server_pb';
 	import type {
 		GetMinecraftVersionsResponse,
 		GetModLoadersResponse,
@@ -22,13 +22,18 @@
 	import {
 		GetMinecraftVersionsRequestSchema,
 		GetModLoadersRequestSchema,
-		GetDockerImagesRequestSchema
+		GetDockerImagesRequestSchema,
+
+		GetTestTPSRegexRequestSchema
+
 	} from '$lib/proto/discopanel/v1/minecraft_pb';
 	import { Alert, AlertDescription } from '$lib/components/ui/alert';
 	import AdditionalPortsEditor from '$lib/components/additional-ports-editor.svelte';
-	import { getUniqueDockerImages } from '$lib/utils';
+	import { compareMinecraftVersion, getUniqueDockerImages } from '$lib/utils';
 	import DockerOverridesEditor from '$lib/components/docker-overrides-editor.svelte';
 	import { enumToString } from '$lib/utils';
+	import { Textarea } from './ui/textarea';
+	import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from './ui/dialog';
 
 	interface Props {
 		server: Server;
@@ -64,7 +69,10 @@
 			dockerImage: server.dockerImage,
 			detached: server.detached,
 			autoStart: server.autoStart,
+			tpsEnabled: server.tpsEnabled,
 			tpsCommand: server.tpsCommand || '',
+			tpsExtractionMode: server.tpsExtractionMode,
+			tpsCustomRegex: server.tpsCustomRegex || '',
 			modpackId: '', // Not used in this context
 			modpackVersionId: '', // Not used in this context
 			additionalPorts: server.additionalPorts || [],
@@ -83,7 +91,15 @@
 			formData.dockerImage !== server.dockerImage ||
 			formData.detached !== server.detached ||
 			formData.autoStart !== server.autoStart ||
-			formData.tpsCommand !== (server.tpsCommand || '') ||
+
+			formData.tpsEnabled !== server.tpsEnabled ||
+        	(formData.tpsEnabled && (
+			    formData.tpsCommand !== (server.tpsCommand || '') ||
+			    formData.tpsExtractionMode !== server.tpsExtractionMode ||
+			    formData.tpsCustomRegex !== (server.tpsCustomRegex || '')
+			)) ||
+
+
 			safeToString(formData.additionalPorts) !== safeToString(server.additionalPorts || []) ||
 			safeToString($state.snapshot(formData.dockerOverrides)) !==
 				safeToString(server.dockerOverrides)
@@ -114,7 +130,10 @@
 				dockerImage: server.dockerImage,
 				detached: server.detached,
 				autoStart: server.autoStart,
+				tpsEnabled: server.tpsEnabled,
 				tpsCommand: server.tpsCommand || '',
+				tpsExtractionMode: server.tpsExtractionMode,
+				tpsCustomRegex: server.tpsCustomRegex || '',
 				modpackId: '', // Not used in this context
 				modpackVersionId: '', // Not used in this context
 				additionalPorts: server.additionalPorts || [],
@@ -192,6 +211,89 @@
 		// The proto doesn't include version compatibility info, so all loaders are shown
 		// Backend has SupportedVersions field but it's not populated or sent via proto
 		return modLoaders?.modloaders || [];
+	}
+
+	function getRecommendedTpsSettings(modLoader: string) {
+        switch (modLoader?.toLowerCase()) {
+			case 'fabric':
+            case 'vanilla':
+				if (compareMinecraftVersion("1.20.3", server.mcVersion) > 0) {console.log("return"); return;}
+                return {
+                    command: 'tick query',
+                    mode: TPSExtractionMode.TPSExtractionModeVanilla
+                };
+            case 'paper':
+            case 'spigot':
+            case 'purpur':
+                return {
+                    command: 'tps',
+                    mode: TPSExtractionMode.TPSExtractionModeSpigot
+                };
+            case 'forge':
+				return {
+                    command: 'forge tps',
+                    mode: TPSExtractionMode.TPSExtractionModeForge
+                };
+            case 'neoforge':
+                return {
+                    command: 'neoforge tps',
+                    mode: TPSExtractionMode.TPSExtractionModeForge
+                };
+            default:
+                return {
+                    command: 'tps',
+                    mode: TPSExtractionMode.TPSExtractionModeLegacy
+                };
+        }
+    }
+
+    let recommended = $derived(getRecommendedTpsSettings(formData.modLoader));
+    let isNotRecommended = $derived(
+        formData.tpsEnabled && recommended != undefined && (
+            formData.tpsCommand !== recommended.command || 
+            formData.tpsExtractionMode !== recommended.mode
+        )
+    );
+
+    function applyRecommendedSettings() {
+		if (recommended == undefined) return;
+        formData.tpsCommand = recommended.command;
+        formData.tpsExtractionMode = recommended.mode;
+    }
+
+	let showRegexModal = $state(false);
+	let testInputText = $state("")
+	let testRegex = $state(formData.tpsCustomRegex || "")
+	let regexResult = $state<number|undefined>(undefined);
+
+	async function openRegexModal() {
+		showRegexModal = true;
+		testRegex = formData.tpsCustomRegex || "";
+		regexResult = undefined;
+		if (server.status === ServerStatus.RUNNING) {
+			const currentTPSCommand = formData.tpsCommand;
+			if(!currentTPSCommand || currentTPSCommand == "") return;
+			const request = create(SendCommandRequestSchema, {
+				id: server.id,
+				command: currentTPSCommand
+			});
+			const response = await rpcClient.server.sendCommand(request)
+			testInputText = response.output;
+		}
+	}
+
+	async function testTPSRegex(){
+		const request = create(GetTestTPSRegexRequestSchema, {
+			input: testInputText,
+			regex: testRegex
+		});
+		const response = await rpcClient.minecraft.getTestTPSRegex(request)
+		regexResult = response.tps;
+	}
+
+	function applyRegex(){
+		showRegexModal = false;
+		formData.tpsCustomRegex = testRegex;
 	}
 </script>
 
@@ -338,20 +440,122 @@
 			</Select>
 		</div>
 
-		<div class="space-y-2">
-			<Label for="tps_command" class="text-sm font-medium"
-				>TPS Command <span class="text-xs text-muted-foreground">(Optional)</span></Label
-			>
-			<Input
-				id="tps_command"
-				placeholder="Polling TPS command"
-				bind:value={formData.tpsCommand}
-				class="h-10"
-			/>
-			<p class="text-xs text-muted-foreground">
-				Override the TPS monitoring command (empty to disable). Use " ?? " to specify fallback
-				commands (e.g., "forge tps ?? neoforge tps ?? tps")
-			</p>
+		<div class="space-y-4 rounded-lg border bg-muted/30 p-4">
+		    <div class="flex items-center justify-between">
+		        <div class="space-y-0.5">
+		            <Label for="tps_enabled" class="cursor-pointer text-sm font-medium">
+		                TPS Monitoring <span class="text-xs text-muted-foreground">(Optional)</span>
+		            </Label>
+		            <p class="text-xs text-muted-foreground">
+		                Automated polling and parsing of server TPS metrics.
+		            </p>
+		        </div>
+		        <div class="flex items-center gap-3">
+		            <!-- Apply Recommended Button -->
+		            {#if isNotRecommended && recommended != undefined}
+		                <Button 
+		                    type="button" 
+		                    variant="outline" 
+		                    size="sm" 
+		                    class="h-7 px-2 text-xs gap-1 border-primary/30 hover:border-primary text-primary transition-all"
+		                    onclick={applyRecommendedSettings}
+		                >
+		                    <WandSparkles class="h-3 w-3" />
+		                    Apply Recommended
+		                </Button>
+		            {/if}
+					
+		            <Switch
+		                id="tps_enabled"
+		                checked={formData.tpsEnabled}
+		                onCheckedChange={(checked) => (formData.tpsEnabled = checked)}
+		            />
+		        </div>
+		    </div>
+		
+		    {#if formData.tpsEnabled}
+		        <Separator />
+		
+		        <div class="space-y-4 pt-1">
+		            <!-- Command Input -->
+		            <div class="space-y-1.5">
+		                <Label for="tps_command" class="text-xs font-medium">Command</Label>
+		                <Input
+		                    id="tps_command"
+		                    placeholder="e.g. tick query"
+		                    bind:value={formData.tpsCommand}
+		                    class="h-9 text-sm"
+		                />
+		                <p class="text-[11px] text-muted-foreground">
+		                    Command sent to console. Use <code class="rounded bg-muted px-1">??</code> for fallbacks (e.g. <code class="rounded bg-muted px-1">forge tps ?? tps</code>).
+		                </p>
+		            </div>
+				
+		            <!-- Extraction Mode Select -->
+		            <div class="space-y-1.5">
+		                <Label for="tps_mode" class="text-xs font-medium">Extraction Strategy</Label>
+		                <Select
+		                    type="single"
+		                    value={String(formData.tpsExtractionMode)}
+		                    onValueChange={(value: string) => {
+		                        formData.tpsExtractionMode = value ? (Number(value) as TPSExtractionMode) : TPSExtractionMode.TPSExtractionModeLegacy;
+		                    }}
+		                >
+		                    <SelectTrigger id="tps_mode" class="h-9 text-sm">
+		                        <span>{TPSExtractionMode[formData.tpsExtractionMode] || 'Select extraction strategy'}</span>
+		                    </SelectTrigger>
+		                    <SelectContent>
+		                        {#each Object.keys(TPSExtractionMode).filter(key => isNaN(Number(key))) as mode (mode)}
+		                            <SelectItem value={String(TPSExtractionMode[mode as keyof typeof TPSExtractionMode])}>
+		                                {mode}
+		                            </SelectItem>
+		                        {/each}
+		                    </SelectContent>
+		                </Select>
+					
+		                <!-- Info Help Texts based on selected Mode -->
+		                <p class="text-[11px] text-muted-foreground">
+		                    {#if formData.tpsExtractionMode === TPSExtractionMode.TPSExtractionModeVanilla}
+		                        Parses TPS from standard Minecraft Vanilla command <code class="rounded bg-muted px-1">/tick query</code> outputs (Version 1.20.3 and newer).
+		                    {:else if formData.tpsExtractionMode === TPSExtractionMode.TPSExtractionModeSpigot}
+		                        Parses TPS from Paper/Spigot command <code class="rounded bg-muted px-1">/tps</code> outputs.
+		                    {:else if formData.tpsExtractionMode === TPSExtractionMode.TPSExtractionModeForge}
+		                        Parses TPS from Forge/NeoForge commands <code class="rounded bg-muted px-1">/forge tps</code> or <code class="rounded bg-muted px-1">/neoforge tps</code> outputs.
+		                    {:else if formData.tpsExtractionMode === TPSExtractionMode.TPSExtractionModeCustom}
+		                        Use a custom Regex to extract the TPS value from your command output.
+		                    {:else if formData.tpsExtractionMode === TPSExtractionMode.TPSExtractionModeLegacy}
+		                        Extract TPS based on Discopanels old extraction logic.
+		                    {/if}
+		                </p>
+		            </div>
+				
+		            <!-- Custom Regex Input (Conditionally Rendered) -->
+		            {#if formData.tpsExtractionMode === TPSExtractionMode.TPSExtractionModeCustom}
+		                <div class="space-y-1.5 rounded-md border border-dashed p-3 bg-background/50">
+							<div class="flex items-center justify-between">
+								<Label for="tps_custom_regex" class="text-xs font-medium">Custom Regex Pattern</Label>
+								<!-- Test Button -->
+								<button
+									type="button"
+									onclick={openRegexModal}
+									class="text-[11px] font-medium text-primary hover:underline flex items-center gap-1"
+								>
+									Test Your Regex
+								</button>
+							</div>
+		                    <Input
+		                        id="tps_custom_regex"
+		                        placeholder="e.g. TPS:\s*([0-9.]+)"
+		                        bind:value={formData.tpsCustomRegex}
+		                        class="h-9 font-mono text-xs"
+		                    />
+		                    <p class="text-[11px] text-muted-foreground">
+		                        Must contain a capture group <code class="rounded bg-muted px-1">(...)</code> pointing to the numerical TPS value. If you don't know what this means, don't use it.
+		                    </p>
+		                </div>
+		            {/if}
+		        </div>
+		    {/if}
 		</div>
 
 		<div class="space-y-4">
@@ -438,3 +642,80 @@
 		</Button>
 	</div>
 </div>
+
+
+<Dialog bind:open={showRegexModal}>
+	<DialogContent class="sm:max-w-2xl w-full p-6">
+		<DialogHeader class="border-b pb-2">
+			<DialogTitle class="text-sm font-semibold">Regex Tester</DialogTitle>
+		</DialogHeader>
+
+		<div class="space-y-4 py-2">
+			<!-- Regex Input -->
+			<div class="space-y-1">
+				<Label class="text-xs">Regex Pattern</Label>
+				<Input 
+					bind:value={testRegex} 
+					class="h-8 font-mono text-xs" 
+					placeholder="z. B. TPS:\s*([0-9.]+)" 
+				/>
+			</div>
+
+			<!-- Test Input Text -->
+			<div class="space-y-1">
+				<Label class="text-xs">Example Text (Start your server and run your TPS command, paste the output here)</Label>
+				<Textarea
+					bind:value={testInputText}
+					rows={6}
+					class="font-mono text-xs"
+					placeholder="Insert TPS Command output here..."
+				/>
+			</div>
+
+			<!-- Test Button -->
+			<Button 
+				type="button" 
+				variant="outline" 
+				size="sm" 
+				onclick={testTPSRegex}
+			>
+				Test
+			</Button>
+
+			<!-- Result Box -->
+			<div class="space-y-1">
+				<Label class="text-xs">Output / Extraction</Label>
+				<div class="rounded-md border bg-muted/30 p-3 font-mono text-xs">
+					{#if regexResult == undefined}
+						<span class="font-medium text-white">Run test to show extracted TPS.</span>
+					{:else if regexResult == 0.0}
+						<span class="font-medium text-destructive">Could not extract TPS</span>
+					{:else}
+						<div class="space-y-1.5 text-green-500">
+								{regexResult}
+						</div>
+					{/if}
+				</div>
+			</div>
+		</div>
+
+		<!-- Actions -->
+		<DialogFooter class="border-t pt-3 gap-2 sm:justify-end">
+			<Button
+				type="button"
+				variant="outline"
+				size="sm"
+				onclick={() => (showRegexModal = false)}
+			>
+				Cancel
+			</Button>
+			<Button
+				type="button"
+				size="sm"
+				onclick={applyRegex}
+			>
+				Apply pattern
+			</Button>
+		</DialogFooter>
+	</DialogContent>
+</Dialog>

--- a/web/discopanel/src/lib/utils.ts
+++ b/web/discopanel/src/lib/utils.ts
@@ -63,3 +63,83 @@ export function enumToString(map: Record<string, unknown>, val: unknown): string
 	}
 	return enumKey.toLowerCase();
 }
+
+// Priority weighting for pre-releases: Higher = Newer
+const TAG_PRIORITY: Record<string, number> = {
+  snapshot: 1,
+  pre: 2,
+  rc: 3,
+  "": 4, // Regular release (no suffix) is the newest
+};
+
+interface ParsedVersion {
+  base: number[];  // e.g., [26, 2]
+  tag: string;     // e.g., "rc", "pre", "snapshot", or ""
+  build: number;   // e.g., 2 in "rc-2"
+}
+
+function parseVersion(v: string): ParsedVersion {
+  // Remove "(Latest)" or similar text from the string
+  const cleanV = v.split("(")[0].trim();
+
+  const pv: ParsedVersion = {
+    base: [],
+    tag: "",
+    build: 0,
+  };
+
+  // Check if a tag (e.g., "-rc-2") is present
+  const [basePart, tagPart] = cleanV.split(/-(.+)/);
+
+  // Parse base version ("26.2" -> [26, 2])
+  pv.base = basePart.split(".").map((p) => parseInt(p, 10) || 0);
+
+  // If tag exists ("rc-2" or "snapshot-1")
+  if (tagPart) {
+    const tagParts = tagPart.split("-");
+    pv.tag = tagParts[0]; // e.g., "rc"
+
+    if (tagParts.length > 1) {
+      pv.build = parseInt(tagParts[1], 10) || 0; // e.g., 2
+    }
+  }
+
+  return pv;
+}
+
+/**
+ * Compares two Minecraft versions.
+ * 
+ * Returns:
+ *  -1 : v1 < v2
+ *   0 : v1 == v2
+ *   1 : v1 > v2
+ */
+export function compareMinecraftVersion(v1: string, v2: string): number {
+  const pv1 = parseVersion(v1);
+  const pv2 = parseVersion(v2);
+
+  // 1. Compare base versions (e.g., 26.3 vs 26.2)
+  const maxLen = Math.max(pv1.base.length, pv2.base.length);
+
+  for (let i = 0; i < maxLen; i++) {
+    const n1 = pv1.base[i] ?? 0;
+    const n2 = pv2.base[i] ?? 0;
+
+    if (n1 < n2) return -1;
+    if (n1 > n2) return 1;
+  }
+
+  // 2. Compare pre-release tag hierarchy (Release > rc > pre > snapshot)
+  const prio1 = TAG_PRIORITY[pv1.tag] ?? 0;
+  const prio2 = TAG_PRIORITY[pv2.tag] ?? 0;
+
+  if (prio1 < prio2) return -1;
+  if (prio1 > prio2) return 1;
+
+  // 3. If tag is identical (e.g., rc-1 vs rc-2), compare build number
+  if (pv1.build < pv2.build) return -1;
+  if (pv1.build > pv2.build) return 1;
+
+  return 0;
+}

--- a/web/discopanel/src/routes/+page.svelte
+++ b/web/discopanel/src/routes/+page.svelte
@@ -521,7 +521,7 @@
 														<Users class="h-3 w-3" />
 														{server.playersOnline || 0}/{server.maxPlayers}
 													</span>
-													{#if server.tps}
+													{#if server.tps && server.tpsEnabled}
 														<span class="flex items-center gap-1 text-xs {getTpsColor(server.tps)}">
 															<Zap class="h-3 w-3" />
 															{server.tps.toFixed(1)} TPS


### PR DESCRIPTION
Implemented new TPS extraction system.

There are 5 Modes:

1. Legacy: How discopanel extracts TPS before this change to keep backward-compatibility. 
2. Vanilla: To extract TPS from Vanilla's `/tick query` command, by calculationg TPS based on Target TPS and Average time per tick (only Vanilla Version 1.20.3 and newer)
3. Spigot: Extract TPS from Spigots `/tps` Command (also orks with Paper and any ModLoaders based on Paper or Spigot)
4. Forge: Extract TPS from Forge's `/forge tps` Command (also works with NeoForge)
5. Custom: Lets the user specify a custom Regex Pattern to extract TPS from the given Command.

This schould also solve this Issue: https://github.com/nickheyer/discopanel/issues/114



